### PR TITLE
feat(js): add currentTime to --status output for executing commands

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-04-23T10:13:02.568Z for PR creation at branch issue-105-0edd650b7149 for issue https://github.com/link-foundation/start/issues/105

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-04-23T10:13:02.568Z for PR creation at branch issue-105-0edd650b7149 for issue https://github.com/link-foundation/start/issues/105

--- a/js/.changeset/issue-105-current-time.md
+++ b/js/.changeset/issue-105-current-time.md
@@ -1,0 +1,5 @@
+---
+'start-command': patch
+---
+
+Add `currentTime` to `--status` output when an execution is still `executing`, so users can see the query time alongside `startTime` and compute how long a command has been running.

--- a/js/src/lib/status-formatter.js
+++ b/js/src/lib/status-formatter.js
@@ -127,6 +127,45 @@ function enrichDetachedStatus(record) {
 }
 
 /**
+ * Wrap a record so its serialized form includes a `currentTime` field when
+ * the status is "executing". This reflects the moment `--status` was invoked,
+ * making it easy to compute how long a command has been running.
+ * The original record is not mutated.
+ * @param {Object} record - Execution record
+ * @returns {Object} Record-like object with `toObject()` augmented when executing
+ */
+function attachCurrentTime(record) {
+  if (!record || record.status !== 'executing') {
+    return record;
+  }
+
+  const currentTime = new Date().toISOString();
+  const wrapped = Object.create(Object.getPrototypeOf(record));
+  Object.assign(wrapped, record);
+  wrapped.currentTime = currentTime;
+  wrapped.toObject = function () {
+    const base =
+      typeof record.toObject === 'function'
+        ? record.toObject.call(this)
+        : { ...this };
+    // Insert currentTime right after startTime for readability
+    const ordered = {};
+    for (const [key, value] of Object.entries(base)) {
+      ordered[key] = value;
+      if (key === 'startTime') {
+        ordered.currentTime = currentTime;
+      }
+    }
+    if (!('currentTime' in ordered)) {
+      ordered.currentTime = currentTime;
+    }
+    return ordered;
+  };
+
+  return wrapped;
+}
+
+/**
  * Format execution record as Links Notation (indented style)
  * Uses nested Links notation for object values (like options) instead of JSON
  *
@@ -192,9 +231,14 @@ function formatRecordAsText(record) {
     `Shell:             ${obj.shell}`,
     `Platform:          ${obj.platform}`,
     `Start Time:        ${obj.startTime}`,
-    `End Time:          ${obj.endTime || 'N/A'}`,
-    `Log Path:          ${obj.logPath}`,
   ];
+  if (obj.currentTime) {
+    lines.push(`Current Time:      ${obj.currentTime}`);
+  }
+  lines.push(
+    `End Time:          ${obj.endTime || 'N/A'}`,
+    `Log Path:          ${obj.logPath}`
+  );
 
   // Format options as nested list instead of JSON
   const optionEntries = Object.entries(obj.options || {}).filter(
@@ -250,9 +294,11 @@ function queryStatus(store, identifier, outputFormat) {
   try {
     // Enrich detached execution status with live session check
     const enrichedRecord = enrichDetachedStatus(record);
+    // Attach currentTime so callers can see how long an executing command has been running
+    const withCurrentTime = attachCurrentTime(enrichedRecord);
     return {
       success: true,
-      output: formatRecord(enrichedRecord, outputFormat || 'links-notation'),
+      output: formatRecord(withCurrentTime, outputFormat || 'links-notation'),
     };
   } catch (err) {
     return { success: false, error: err.message };
@@ -266,4 +312,5 @@ module.exports = {
   queryStatus,
   isDetachedSessionAlive,
   enrichDetachedStatus,
+  attachCurrentTime,
 };

--- a/js/test/session-name-status.test.js
+++ b/js/test/session-name-status.test.js
@@ -18,6 +18,7 @@ const {
   queryStatus,
   isDetachedSessionAlive,
   enrichDetachedStatus,
+  attachCurrentTime,
 } = require('../src/lib/status-formatter');
 
 // Use temp directory for tests
@@ -305,6 +306,74 @@ describe('Issue #101: Detached status enrichment', () => {
         expect(enriched.endTime).not.toBeNull();
       }
     });
+  });
+});
+
+describe('Issue #105: attachCurrentTime for executing status', () => {
+  it('should add currentTime to serialization when status is executing', () => {
+    const record = new ExecutionRecord({
+      command: 'sleep 60',
+      pid: 12345,
+      logPath: '/tmp/test.log',
+    });
+
+    const before = Date.now();
+    const wrapped = attachCurrentTime(record);
+    const obj = wrapped.toObject();
+    const after = Date.now();
+
+    expect(obj.currentTime).toBeDefined();
+    const currentTimeMs = new Date(obj.currentTime).getTime();
+    expect(Number.isNaN(currentTimeMs)).toBe(false);
+    expect(currentTimeMs).toBeGreaterThanOrEqual(before - 1);
+    expect(currentTimeMs).toBeLessThanOrEqual(after + 1);
+  });
+
+  it('should not add currentTime when status is executed', () => {
+    const record = new ExecutionRecord({
+      command: 'echo hello',
+      pid: 12345,
+      logPath: '/tmp/test.log',
+    });
+    record.complete(0);
+
+    const wrapped = attachCurrentTime(record);
+    // attachCurrentTime should return the original record unchanged
+    expect(wrapped).toBe(record);
+    const obj = wrapped.toObject();
+    expect(obj.currentTime).toBeUndefined();
+  });
+
+  it('should not mutate the original record', () => {
+    const record = new ExecutionRecord({
+      command: 'sleep 60',
+      pid: 12345,
+      logPath: '/tmp/test.log',
+    });
+
+    const wrapped = attachCurrentTime(record);
+    expect(wrapped).not.toBe(record);
+    // The original record's toObject output should not include currentTime
+    const originalObj = record.toObject();
+    expect(originalObj.currentTime).toBeUndefined();
+  });
+
+  it('should place currentTime right after startTime in serialization order', () => {
+    const record = new ExecutionRecord({
+      command: 'sleep 60',
+      pid: 12345,
+      logPath: '/tmp/test.log',
+    });
+
+    const wrapped = attachCurrentTime(record);
+    const keys = Object.keys(wrapped.toObject());
+    const startIndex = keys.indexOf('startTime');
+    expect(startIndex).toBeGreaterThanOrEqual(0);
+    expect(keys[startIndex + 1]).toBe('currentTime');
+  });
+
+  it('should handle null record gracefully', () => {
+    expect(attachCurrentTime(null)).toBeNull();
   });
 });
 

--- a/js/test/status-query.test.js
+++ b/js/test/status-query.test.js
@@ -191,6 +191,102 @@ describe('--status query functionality', () => {
       expect(parsed.exitCode).toBeNull();
       expect(parsed.endTime).toBeNull();
     });
+
+    it('should include currentTime for executing commands (JSON)', () => {
+      const beforeQuery = Date.now();
+      const executingRecord = new ExecutionRecord({
+        command: 'sleep 100',
+        pid: 99999,
+        logPath: '/tmp/executing.log',
+      });
+      store.save(executingRecord);
+
+      const result = runCli([
+        '--status',
+        executingRecord.uuid,
+        '--output-format',
+        'json',
+      ]);
+
+      expect(result.exitCode).toBe(0);
+      const parsed = JSON.parse(result.stdout);
+      expect(parsed.currentTime).toBeDefined();
+      // currentTime should be a valid ISO timestamp at or after the query started
+      const currentTimeMs = new Date(parsed.currentTime).getTime();
+      expect(Number.isNaN(currentTimeMs)).toBe(false);
+      expect(currentTimeMs).toBeGreaterThanOrEqual(beforeQuery - 1);
+      expect(currentTimeMs).toBeLessThanOrEqual(Date.now() + 1);
+      // Should be >= startTime
+      expect(currentTimeMs).toBeGreaterThanOrEqual(
+        new Date(parsed.startTime).getTime()
+      );
+    });
+
+    it('should not include currentTime for completed commands (JSON)', () => {
+      // testRecord from beforeEach is already completed
+      const result = runCli([
+        '--status',
+        testRecord.uuid,
+        '--output-format',
+        'json',
+      ]);
+
+      expect(result.exitCode).toBe(0);
+      const parsed = JSON.parse(result.stdout);
+      expect(parsed.status).toBe('executed');
+      expect(parsed.currentTime).toBeUndefined();
+    });
+
+    it('should include currentTime in links-notation for executing commands', () => {
+      const executingRecord = new ExecutionRecord({
+        command: 'sleep 100',
+        pid: 99999,
+        logPath: '/tmp/executing.log',
+      });
+      store.save(executingRecord);
+
+      const result = runCli(['--status', executingRecord.uuid]);
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('status executing');
+      // currentTime should appear as an indented property with an ISO timestamp value
+      expect(result.stdout).toMatch(
+        /\n {2}currentTime "\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/
+      );
+    });
+
+    it('should include Current Time in text format for executing commands', () => {
+      const executingRecord = new ExecutionRecord({
+        command: 'sleep 100',
+        pid: 99999,
+        logPath: '/tmp/executing.log',
+      });
+      store.save(executingRecord);
+
+      const result = runCli([
+        '--status',
+        executingRecord.uuid,
+        '--output-format',
+        'text',
+      ]);
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('Status:');
+      expect(result.stdout).toContain('executing');
+      expect(result.stdout).toContain('Current Time:');
+    });
+
+    it('should not include Current Time in text format for completed commands', () => {
+      const result = runCli([
+        '--status',
+        testRecord.uuid,
+        '--output-format',
+        'text',
+      ]);
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).not.toContain('Current Time:');
+    });
   });
 });
 


### PR DESCRIPTION
## Summary

Closes #105.

When `$ --status <uuid-or-session>` is called for a command that is still `executing`, the output now includes a new `currentTime` field next to `startTime`. This makes it trivial to see how long a command has been running (just subtract `startTime` from `currentTime`).

### Before

```
4854c1e6-be73-4dd5-8c3a-ff6c8a854993
  uuid 4854c1e6-...
  status executing
  command "solve https://github.com/..."
  logPath /tmp/.../4854c1e6-...log
  startTime "2026-04-23T10:02:57.786Z"
  workingDirectory /home/box
```

### After

```
4854c1e6-be73-4dd5-8c3a-ff6c8a854993
  uuid 4854c1e6-...
  status executing
  command "solve https://github.com/..."
  logPath /tmp/.../4854c1e6-...log
  startTime "2026-04-23T10:02:57.786Z"
  currentTime "2026-04-23T10:10:13.042Z"
  workingDirectory /home/box
```

`currentTime` is only added when the status is `executing`; for finished executions the output is unchanged (`endTime` already reflects completion).

## Changes

- `js/src/lib/status-formatter.js`: new `attachCurrentTime()` helper that wraps the enriched record and augments its `toObject()` to include `currentTime` right after `startTime`. Wired into `queryStatus()` so all three formats (links-notation, JSON, text) benefit.
- `js/test/status-query.test.js`: integration tests covering all three formats — executing records include `currentTime`, completed records do not.
- `js/test/session-name-status.test.js`: unit tests for `attachCurrentTime()` (executing vs executed, non-mutation, key ordering, null input).
- `js/.changeset/issue-105-current-time.md`: patch changeset.

## Test plan

- [x] `bun test test/status-query.test.js test/session-name-status.test.js` → 32/32 pass, 90 expect() calls
- [x] `bun run lint` → clean
- [x] `bun run format:check` → clean
- [x] Manual CLI check with an `executing` record:
  - `--status <uuid>` (default links-notation) includes `currentTime "..."`
  - `--status <uuid> --output-format json` includes `"currentTime": "..."`
  - `--status <uuid> --output-format text` includes `Current Time: ...`
- [x] Manual CLI check with a completed record: `currentTime` / `Current Time:` absent in all formats.

### Reproducing the issue

Create or attach to a long-running command (e.g. `$ --isolated screen -d -s my-session -- solve ...`) and repeatedly run `$ --status my-session`. Before this PR the output only shows `startTime`, so you have to read the clock yourself; after this PR it shows both, so elapsed time is obvious.

Note: the 2 pre-existing failures in `test/args-parser.test.js` (regex `/requires a UUID argument/`) are unrelated — they exist on `main` because an earlier commit changed the error message to "UUID or session name" without updating the expected regex in the test.