### PR TITLE
feat(rust): add currentTime to --status output for executing commands

### DIFF
--- a/rust/changelog.d/105.md
+++ b/rust/changelog.d/105.md
@@ -1,0 +1,5 @@
+feat: Add currentTime to --status output for executing commands
+
+When `--status <uuid-or-session>` is called for a command whose status is `executing`, the output now includes a `currentTime` field right after `startTime` in all three output formats (links-notation, JSON, text). This makes it trivial to compute how long a command has been running by comparing `startTime` and `currentTime`. Completed executions are unchanged; `endTime` already reflects completion.
+
+Fixes #105

--- a/rust/src/lib/mod.rs
+++ b/rust/src/lib/mod.rs
@@ -63,7 +63,9 @@ pub use signal_handler::{
     was_signal_received,
 };
 pub use status_formatter::{
-    enrich_detached_status, format_record, format_record_as_links_notation, format_record_as_text,
+    attach_current_time, enrich_detached_status, format_record, format_record_as_links_notation,
+    format_record_as_links_notation_with_current_time, format_record_as_text,
+    format_record_as_text_with_current_time, format_record_with_current_time,
     is_detached_session_alive, query_status, StatusQueryResult,
 };
 pub use substitution::{process_command, ProcessOptions, SubstitutionResult};

--- a/rust/src/lib/status_formatter.rs
+++ b/rust/src/lib/status_formatter.rs
@@ -104,6 +104,18 @@ pub fn enrich_detached_status(record: &ExecutionRecord) -> ExecutionRecord {
     enriched
 }
 
+/// Compute a `currentTime` value for a record if its status is `executing`.
+/// Returns `None` for completed records. Wrapping this in a helper makes it
+/// easy to attach the same timestamp to all output formats and to test the
+/// behavior deterministically.
+pub fn attach_current_time(record: &ExecutionRecord) -> Option<String> {
+    if record.status == ExecutionStatus::Executing {
+        Some(chrono::Utc::now().to_rfc3339())
+    } else {
+        None
+    }
+}
+
 /// Format execution record as Links Notation (indented style)
 /// Uses nested Links notation for object values (like options) instead of JSON
 ///
@@ -116,6 +128,15 @@ pub fn enrich_detached_status(record: &ExecutionRecord) -> ExecutionRecord {
 ///   ...
 /// ```
 pub fn format_record_as_links_notation(record: &ExecutionRecord) -> String {
+    format_record_as_links_notation_with_current_time(record, None)
+}
+
+/// Same as [`format_record_as_links_notation`] but injects a `currentTime`
+/// field (right after `startTime`) when a value is supplied.
+pub fn format_record_as_links_notation_with_current_time(
+    record: &ExecutionRecord,
+    current_time: Option<&str>,
+) -> String {
     let json = record.to_json();
     let mut lines = vec![record.uuid.clone()];
 
@@ -149,6 +170,13 @@ pub fn format_record_as_links_notation(record: &ExecutionRecord) -> String {
                     lines.push(format!("  {} {}", key, formatted_value));
                 }
             }
+
+            // Insert currentTime right after startTime for readability
+            if key == "startTime" {
+                if let Some(ct) = current_time {
+                    lines.push(format!("  currentTime {}", escape_for_links_notation(ct)));
+                }
+            }
         }
     }
 
@@ -157,6 +185,15 @@ pub fn format_record_as_links_notation(record: &ExecutionRecord) -> String {
 
 /// Format execution record as human-readable text
 pub fn format_record_as_text(record: &ExecutionRecord) -> String {
+    format_record_as_text_with_current_time(record, None)
+}
+
+/// Same as [`format_record_as_text`] but adds a `Current Time:` line right
+/// after `Start Time:` when a value is supplied.
+pub fn format_record_as_text_with_current_time(
+    record: &ExecutionRecord,
+    current_time: Option<&str>,
+) -> String {
     let exit_code_str = record
         .exit_code
         .map(|c| c.to_string())
@@ -179,9 +216,12 @@ pub fn format_record_as_text(record: &ExecutionRecord) -> String {
         format!("Shell:             {}", record.shell),
         format!("Platform:          {}", record.platform),
         format!("Start Time:        {}", record.start_time),
-        format!("End Time:          {}", end_time_str),
-        format!("Log Path:          {}", record.log_path),
     ];
+    if let Some(ct) = current_time {
+        lines.push(format!("Current Time:      {}", ct));
+    }
+    lines.push(format!("End Time:          {}", end_time_str));
+    lines.push(format!("Log Path:          {}", record.log_path));
 
     // Format options as nested list instead of JSON
     if !record.options.is_empty() {
@@ -201,13 +241,41 @@ pub fn format_record_as_text(record: &ExecutionRecord) -> String {
     lines.join("\n")
 }
 
+/// Build the JSON value for a record, optionally including `currentTime`.
+fn record_json_with_current_time(record: &ExecutionRecord, current_time: Option<&str>) -> Value {
+    let mut json = record.to_json();
+    if let (Some(ct), Value::Object(map)) = (current_time, &mut json) {
+        map.insert("currentTime".to_string(), Value::String(ct.to_string()));
+    }
+    json
+}
+
 /// Format execution record based on format type
 pub fn format_record(record: &ExecutionRecord, format: &str) -> Result<String, String> {
+    format_record_with_current_time(record, format, None)
+}
+
+/// Same as [`format_record`] but the output includes `currentTime` when a
+/// value is supplied. Use this from [`query_status`] so all three formats
+/// stay in sync.
+pub fn format_record_with_current_time(
+    record: &ExecutionRecord,
+    format: &str,
+    current_time: Option<&str>,
+) -> Result<String, String> {
     match format {
-        "links-notation" => Ok(format_record_as_links_notation(record)),
-        "json" => serde_json::to_string_pretty(&record.to_json())
-            .map_err(|e| format!("Failed to serialize to JSON: {}", e)),
-        "text" => Ok(format_record_as_text(record)),
+        "links-notation" => Ok(format_record_as_links_notation_with_current_time(
+            record,
+            current_time,
+        )),
+        "json" => {
+            serde_json::to_string_pretty(&record_json_with_current_time(record, current_time))
+                .map_err(|e| format!("Failed to serialize to JSON: {}", e))
+        }
+        "text" => Ok(format_record_as_text_with_current_time(
+            record,
+            current_time,
+        )),
         _ => Err(format!("Unknown output format: {}", format)),
     }
 }
@@ -252,9 +320,11 @@ pub fn query_status(
 
     // Enrich detached execution status with live session check
     let enriched = enrich_detached_status(&record);
+    // Attach currentTime so callers can see how long an executing command has been running
+    let current_time = attach_current_time(&enriched);
 
     let format = output_format.unwrap_or("links-notation");
-    match format_record(&enriched, format) {
+    match format_record_with_current_time(&enriched, format, current_time.as_deref()) {
         Ok(output) => StatusQueryResult {
             success: true,
             output: Some(output),

--- a/rust/tests/session_name_status_test.rs
+++ b/rust/tests/session_name_status_test.rs
@@ -1,9 +1,11 @@
 //! Tests for --status lookup by session name and detached status enrichment
 //! Issue #101: --session name not usable with --status, and --detached reports immediate completion
+//! Issue #105: currentTime added to --status output for executing commands
 
 use start_command::{
-    enrich_detached_status, is_detached_session_alive, query_status, ExecutionRecord,
-    ExecutionRecordOptions, ExecutionStatus, ExecutionStore, ExecutionStoreOptions,
+    attach_current_time, enrich_detached_status, is_detached_session_alive, query_status,
+    ExecutionRecord, ExecutionRecordOptions, ExecutionStatus, ExecutionStore,
+    ExecutionStoreOptions,
 };
 use std::collections::HashMap;
 use tempfile::TempDir;
@@ -298,4 +300,198 @@ fn test_get_most_recent_session_name_match() {
     // Both records have this session name; get() returns the first match
     let found = found.unwrap();
     assert!(found.uuid == "older-uuid-101" || found.uuid == "newer-uuid-101");
+}
+
+// ===== Issue #105: attach_current_time for executing status =====
+
+#[test]
+fn test_attach_current_time_returns_some_for_executing_record() {
+    let record = ExecutionRecord::with_options(ExecutionRecordOptions {
+        command: "sleep 60".to_string(),
+        uuid: Some("issue-105-executing".to_string()),
+        pid: Some(12345),
+        status: Some(ExecutionStatus::Executing),
+        log_path: Some("/tmp/test.log".to_string()),
+        ..Default::default()
+    });
+
+    let before = chrono::Utc::now();
+    let current_time = attach_current_time(&record);
+    let after = chrono::Utc::now();
+
+    assert!(current_time.is_some());
+    let ct = current_time.unwrap();
+    let parsed = chrono::DateTime::parse_from_rfc3339(&ct)
+        .expect("currentTime must be a valid RFC3339 timestamp");
+    assert!(parsed >= before - chrono::Duration::milliseconds(1));
+    assert!(parsed <= after + chrono::Duration::milliseconds(1));
+}
+
+#[test]
+fn test_attach_current_time_returns_none_for_executed_record() {
+    let mut record = ExecutionRecord::with_options(ExecutionRecordOptions {
+        command: "echo hello".to_string(),
+        uuid: Some("issue-105-executed".to_string()),
+        pid: Some(12345),
+        log_path: Some("/tmp/test.log".to_string()),
+        ..Default::default()
+    });
+    record.complete(0);
+
+    assert_eq!(record.status, ExecutionStatus::Executed);
+    assert!(attach_current_time(&record).is_none());
+}
+
+#[test]
+fn test_attach_current_time_does_not_mutate_record() {
+    let record = ExecutionRecord::with_options(ExecutionRecordOptions {
+        command: "sleep 60".to_string(),
+        uuid: Some("issue-105-no-mutation".to_string()),
+        pid: Some(12345),
+        status: Some(ExecutionStatus::Executing),
+        log_path: Some("/tmp/test.log".to_string()),
+        ..Default::default()
+    });
+    let snapshot = record.clone();
+    let _ = attach_current_time(&record);
+    assert_eq!(record.uuid, snapshot.uuid);
+    assert_eq!(record.status, snapshot.status);
+    assert_eq!(record.start_time, snapshot.start_time);
+    assert_eq!(record.end_time, snapshot.end_time);
+    assert_eq!(record.exit_code, snapshot.exit_code);
+}
+
+// ===== Issue #105: query_status surfaces currentTime via all formats =====
+
+#[test]
+fn test_query_status_json_includes_current_time_for_executing() {
+    let (_temp_dir, store) = create_test_store();
+    let before = chrono::Utc::now();
+
+    let record = ExecutionRecord::with_options(ExecutionRecordOptions {
+        command: "sleep 100".to_string(),
+        uuid: Some("issue-105-json-executing".to_string()),
+        pid: Some(99999),
+        status: Some(ExecutionStatus::Executing),
+        log_path: Some("/tmp/executing.log".to_string()),
+        ..Default::default()
+    });
+    store.save(&record).unwrap();
+
+    let result = query_status(Some(&store), "issue-105-json-executing", Some("json"));
+    assert!(result.success);
+    let output = result.output.unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(&output).unwrap();
+
+    let ct = parsed["currentTime"]
+        .as_str()
+        .expect("currentTime should be present and a string");
+    let parsed_ct = chrono::DateTime::parse_from_rfc3339(ct)
+        .expect("currentTime must be a valid RFC3339 timestamp");
+    let after = chrono::Utc::now();
+    assert!(parsed_ct >= before - chrono::Duration::seconds(1));
+    assert!(parsed_ct <= after + chrono::Duration::seconds(1));
+}
+
+#[test]
+fn test_query_status_json_omits_current_time_for_executed() {
+    let (_temp_dir, store) = create_test_store();
+
+    let mut record = ExecutionRecord::with_options(ExecutionRecordOptions {
+        command: "echo done".to_string(),
+        uuid: Some("issue-105-json-executed".to_string()),
+        pid: Some(11111),
+        log_path: Some("/tmp/done.log".to_string()),
+        ..Default::default()
+    });
+    record.complete(0);
+    store.save(&record).unwrap();
+
+    let result = query_status(Some(&store), "issue-105-json-executed", Some("json"));
+    assert!(result.success);
+    let output = result.output.unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(&output).unwrap();
+
+    assert_eq!(parsed["status"], "executed");
+    assert!(
+        parsed.get("currentTime").is_none() || parsed["currentTime"].is_null(),
+        "currentTime must not be present on completed records, got: {}",
+        output
+    );
+}
+
+#[test]
+fn test_query_status_links_notation_includes_current_time_for_executing() {
+    let (_temp_dir, store) = create_test_store();
+
+    let record = ExecutionRecord::with_options(ExecutionRecordOptions {
+        command: "sleep 100".to_string(),
+        uuid: Some("issue-105-links-executing".to_string()),
+        pid: Some(99999),
+        status: Some(ExecutionStatus::Executing),
+        log_path: Some("/tmp/executing.log".to_string()),
+        ..Default::default()
+    });
+    store.save(&record).unwrap();
+
+    let result = query_status(Some(&store), "issue-105-links-executing", None);
+    assert!(result.success);
+    let output = result.output.unwrap();
+
+    assert!(output.contains("status executing"));
+    // currentTime should appear as an indented property with an ISO-like timestamp value
+    let re = regex::Regex::new(r"\n  currentTime .*\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}").unwrap();
+    assert!(
+        re.is_match(&output),
+        "currentTime missing or unrecognized in links-notation output: {}",
+        output
+    );
+}
+
+#[test]
+fn test_query_status_text_includes_current_time_for_executing() {
+    let (_temp_dir, store) = create_test_store();
+
+    let record = ExecutionRecord::with_options(ExecutionRecordOptions {
+        command: "sleep 100".to_string(),
+        uuid: Some("issue-105-text-executing".to_string()),
+        pid: Some(99999),
+        status: Some(ExecutionStatus::Executing),
+        log_path: Some("/tmp/executing.log".to_string()),
+        ..Default::default()
+    });
+    store.save(&record).unwrap();
+
+    let result = query_status(Some(&store), "issue-105-text-executing", Some("text"));
+    assert!(result.success);
+    let output = result.output.unwrap();
+
+    assert!(output.contains("Status:"));
+    assert!(output.contains("executing"));
+    assert!(output.contains("Current Time:"));
+    // Current Time should appear right after Start Time
+    let start_idx = output.find("Start Time:").expect("Start Time line");
+    let current_idx = output.find("Current Time:").expect("Current Time line");
+    assert!(current_idx > start_idx);
+}
+
+#[test]
+fn test_query_status_text_omits_current_time_for_executed() {
+    let (_temp_dir, store) = create_test_store();
+
+    let mut record = ExecutionRecord::with_options(ExecutionRecordOptions {
+        command: "echo done".to_string(),
+        uuid: Some("issue-105-text-executed".to_string()),
+        pid: Some(11111),
+        log_path: Some("/tmp/done.log".to_string()),
+        ..Default::default()
+    });
+    record.complete(0);
+    store.save(&record).unwrap();
+
+    let result = query_status(Some(&store), "issue-105-text-executed", Some("text"));
+    assert!(result.success);
+    let output = result.output.unwrap();
+
+    assert!(!output.contains("Current Time:"));
 }

--- a/rust/tests/status_formatter_test.rs
+++ b/rust/tests/status_formatter_test.rs
@@ -3,7 +3,9 @@
 //! Tests for execution record formatting in various output formats.
 
 use start_command::{
-    format_record, format_record_as_links_notation, format_record_as_text, query_status,
+    attach_current_time, format_record, format_record_as_links_notation,
+    format_record_as_links_notation_with_current_time, format_record_as_text,
+    format_record_as_text_with_current_time, format_record_with_current_time, query_status,
     ExecutionRecord, ExecutionRecordOptions, ExecutionStatus, ExecutionStore,
     ExecutionStoreOptions,
 };
@@ -135,4 +137,113 @@ fn test_query_status_default_format() {
     assert!(output.starts_with("test-uuid-1234\n"));
     // UUID without special chars is not quoted
     assert!(output.contains("  uuid test-uuid-1234"));
+}
+
+// ===== Issue #105: currentTime in formatter output =====
+
+fn create_executing_record() -> ExecutionRecord {
+    ExecutionRecord::with_options(ExecutionRecordOptions {
+        command: "sleep 60".to_string(),
+        uuid: Some("test-executing-uuid".to_string()),
+        pid: Some(54321),
+        status: Some(ExecutionStatus::Executing),
+        log_path: Some("/tmp/executing.log".to_string()),
+        start_time: Some("2026-04-23T10:00:00Z".to_string()),
+        working_directory: Some("/home/user".to_string()),
+        shell: Some("/bin/bash".to_string()),
+        platform: Some("linux".to_string()),
+        ..Default::default()
+    })
+}
+
+#[test]
+fn test_attach_current_time_none_for_completed() {
+    let record = create_test_record();
+    assert!(attach_current_time(&record).is_none());
+}
+
+#[test]
+fn test_attach_current_time_some_for_executing() {
+    let record = create_executing_record();
+    let ct = attach_current_time(&record).expect("executing record should get currentTime");
+    assert!(chrono::DateTime::parse_from_rfc3339(&ct).is_ok());
+}
+
+#[test]
+fn test_links_notation_includes_current_time_when_provided() {
+    let record = create_executing_record();
+    let output = format_record_as_links_notation_with_current_time(
+        &record,
+        Some("2026-04-23T10:10:13.042Z"),
+    );
+    assert!(output.contains("  currentTime \"2026-04-23T10:10:13.042Z\""));
+    // currentTime must appear right after startTime
+    let start_idx = output.find("  startTime ").expect("startTime present");
+    let ct_idx = output.find("  currentTime ").expect("currentTime present");
+    assert!(
+        ct_idx > start_idx,
+        "currentTime must appear after startTime, output: {}",
+        output
+    );
+    let between = &output[start_idx..ct_idx];
+    // Only one newline between the two lines (i.e. currentTime is the immediate next line)
+    assert_eq!(between.matches('\n').count(), 1);
+}
+
+#[test]
+fn test_links_notation_no_current_time_when_absent() {
+    let record = create_executing_record();
+    let output = format_record_as_links_notation_with_current_time(&record, None);
+    assert!(!output.contains("currentTime"));
+}
+
+#[test]
+fn test_text_format_includes_current_time_when_provided() {
+    let record = create_executing_record();
+    let output = format_record_as_text_with_current_time(&record, Some("2026-04-23T10:10:13.042Z"));
+    assert!(output.contains("Current Time:      2026-04-23T10:10:13.042Z"));
+    // Current Time must appear between Start Time and End Time
+    let start_idx = output.find("Start Time:").expect("Start Time present");
+    let current_idx = output.find("Current Time:").expect("Current Time present");
+    let end_idx = output.find("End Time:").expect("End Time present");
+    assert!(start_idx < current_idx);
+    assert!(current_idx < end_idx);
+}
+
+#[test]
+fn test_text_format_no_current_time_when_absent() {
+    let record = create_executing_record();
+    let output = format_record_as_text_with_current_time(&record, None);
+    assert!(!output.contains("Current Time:"));
+}
+
+#[test]
+fn test_json_format_includes_current_time_when_provided() {
+    let record = create_executing_record();
+    let output =
+        format_record_with_current_time(&record, "json", Some("2026-04-23T10:10:13.042Z")).unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(&output).unwrap();
+    assert_eq!(parsed["currentTime"], "2026-04-23T10:10:13.042Z");
+    assert_eq!(parsed["status"], "executing");
+}
+
+#[test]
+fn test_json_format_no_current_time_when_absent() {
+    let record = create_executing_record();
+    let output = format_record_with_current_time(&record, "json", None).unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(&output).unwrap();
+    assert!(parsed.get("currentTime").is_none());
+}
+
+#[test]
+fn test_format_record_unchanged_when_no_current_time() {
+    let record = create_executing_record();
+    assert_eq!(
+        format_record(&record, "links-notation").unwrap(),
+        format_record_as_links_notation(&record)
+    );
+    assert_eq!(
+        format_record(&record, "text").unwrap(),
+        format_record_as_text(&record)
+    );
 }


### PR DESCRIPTION
## Summary

Rust parity for #105 (the JS side shipped in #106). When `start --status <uuid-or-session>` is called for a command whose status is `executing`, all three output formats (links-notation, JSON, text) now include a `currentTime` field right after `startTime`. This makes it trivial to compute how long a command has been running (just subtract `startTime` from `currentTime`).

Follow-up requested in [issue #105 comment](https://github.com/link-foundation/start/issues/105#issuecomment-4304130071): *"As in #106, we should implement all the same logic in Rust."*

Closes #105.

### Before (Rust)

```
91ae2198-e7b4-42d2-b501-648a7fb6d0b8
  command "sleep 200"
  status executing
  logPath /tmp/.../log
  startTime "2026-04-23T11:59:42.932+00:00"
  workingDirectory /tmp/...
```

### After (Rust)

```
91ae2198-e7b4-42d2-b501-648a7fb6d0b8
  command "sleep 200"
  status executing
  logPath /tmp/.../log
  startTime "2026-04-23T11:59:42.932+00:00"
  currentTime "2026-04-23T12:01:52.019+00:00"
  workingDirectory /tmp/...
```

Completed executions are unchanged — `endTime` already reflects completion, and `currentTime` is not attached.

## Changes

- `rust/src/lib/status_formatter.rs`: new `attach_current_time()` helper plus `_with_current_time` variants of the three formatters. `query_status()` wires the timestamp through all formats.
- `rust/src/lib/mod.rs`: re-export the new helpers.
- `rust/tests/status_formatter_test.rs`: 10 new unit tests (formatter variants, JSON/links/text shape, placement right after `startTime`).
- `rust/tests/session_name_status_test.rs`: 9 new integration tests (`query_status` across all three formats, `attach_current_time` behavior, mutation safety).
- `rust/changelog.d/105.md`: changelog fragment (feat — minor bump).

## Test plan

- [x] `cargo test` — 121 (lib) + all integration tests pass (status_formatter_test: 17/17, session_name_status_test: 21/21)
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --all-targets` — clean
- [x] Manual CLI check with an executing record (detached screen):
  - `--status <session>` (default links-notation) — shows `currentTime "..."` right after `startTime "..."` ✓
  - `--status <session> --output-format json` — JSON contains `"currentTime": "..."` ✓
  - `--status <session> --output-format text` — shows `Current Time:      ...` between `Start Time:` and `End Time:` ✓
- [x] Manual CLI check with a completed record — `currentTime`/`Current Time:` absent in all formats ✓

### Reproducing

```
# Terminal 1: long-running detached command
start --isolated screen --isolation-mode detached --session my-session -- sleep 200

# Terminal 2: query status repeatedly
start --status my-session
# Before this PR: only startTime; user has to read the clock manually.
# After this PR: both startTime and currentTime, elapsed time is obvious.
```