### PR TITLE
fix: record docker image-preparation phase (docker pull) in the session log (#138)

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-06-19T09:57:10.795Z for PR creation at branch issue-138-3f4ef74d216e for issue https://github.com/link-foundation/start/issues/138

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-06-19T09:57:10.795Z for PR creation at branch issue-138-3f4ef74d216e for issue https://github.com/link-foundation/start/issues/138

--- a/js/.changeset/detached-docker-image-prep-log.md
+++ b/js/.changeset/detached-docker-image-prep-log.md
@@ -1,0 +1,5 @@
+---
+'start-command': patch
+---
+
+Record the docker image-preparation phase in the session log (issue #138). When a `--isolated docker` run needs to `docker pull` an image, the pull output is now teed into the session-log file (`/tmp/start-command/logs/isolation/docker/<uuid>.log`) in real time and bracketed with `Preparing image <name>…` / `Image ready (<duration>)` markers (or `Image preparation failed` on error). Previously the minutes spent pulling a (potentially multi-GB) image left no trace in the log, so operators tailing `$ --upload-log <uuid>` during startup saw only the header. The single session-log file is now a gap-free record of the run, including the longest, most failure-prone phase.

--- a/js/src/lib/docker-utils.js
+++ b/js/src/lib/docker-utils.js
@@ -113,8 +113,11 @@ function dockerImageExists(image) {
  * docker's own exit code is recovered via a sentinel status file because the
  * exit status of a `cmd | tee` pipeline reflects tee, not docker.
  *
- * Without a logPath (or on Windows), it falls back to the previous behavior:
- * inherited stdio for real-time console output, with no log capture.
+ * Without a logPath, it falls back to the previous behavior: inherited stdio
+ * for real-time console output, with no log capture. On Windows (no portable
+ * shell `tee`) but with a logPath, the pull output is captured, echoed to the
+ * console, and appended to the log after the pull so the session log still
+ * records the image-preparation phase (issue #138) — just not streamed live.
  *
  * @param {string} image - Docker image to pull
  * @param {string|null} logPath - Session log file to append pull output to
@@ -123,12 +126,36 @@ function dockerImageExists(image) {
 function runDockerPull(image, logPath) {
   const { shellQuote } = require('./isolation-log-utils');
 
-  // Without a log target (or on Windows where tee is unreliable), keep the
-  // original inherited-stdio behavior for fancy real-time console output.
-  if (!logPath || process.platform === 'win32') {
+  // Without a log target, keep the original inherited-stdio behavior for
+  // fancy real-time console output.
+  if (!logPath) {
     return spawnSync('docker', ['pull', image], {
       stdio: ['pipe', 'inherit', 'inherit'],
     });
+  }
+
+  // Windows has no portable shell `tee`, so capture the pull output, echo it to
+  // the console, and append it to the log so the image-preparation phase is
+  // still recorded in the session log (issue #138), just not streamed live.
+  if (process.platform === 'win32') {
+    const { appendLogFile } = require('./isolation-log-utils');
+    const result = spawnSync('docker', ['pull', image], {
+      stdio: ['pipe', 'pipe', 'pipe'],
+      encoding: 'utf8',
+    });
+    const combined = `${result.stdout || ''}${result.stderr || ''}`;
+    if (combined) {
+      process.stdout.write(combined);
+      try {
+        appendLogFile(
+          logPath,
+          combined.endsWith('\n') ? combined : `${combined}\n`
+        );
+      } catch {
+        // best-effort: log capture must never break the pull
+      }
+    }
+    return result;
   }
 
   // Tee docker pull output to both the console and the log file. docker writes

--- a/js/src/lib/docker-utils.js
+++ b/js/src/lib/docker-utils.js
@@ -7,6 +7,8 @@
  */
 
 const fs = require('fs');
+const os = require('os');
+const path = require('path');
 const { execSync, spawnSync } = require('child_process');
 
 /**
@@ -103,30 +105,113 @@ function dockerImageExists(image) {
 }
 
 /**
- * Pull a Docker image with output streaming
- * Displays the pull operation as a virtual command in the timeline
+ * Run `docker pull <image>` while teeing its output to the session log file.
+ *
+ * When a logPath is given (and tee is available, i.e. non-Windows), the pull
+ * output is streamed to BOTH the console and the log file in real time so the
+ * image-preparation phase is captured in the single session log (issue #138).
+ * docker's own exit code is recovered via a sentinel status file because the
+ * exit status of a `cmd | tee` pipeline reflects tee, not docker.
+ *
+ * Without a logPath (or on Windows), it falls back to the previous behavior:
+ * inherited stdio for real-time console output, with no log capture.
+ *
  * @param {string} image - Docker image to pull
+ * @param {string|null} logPath - Session log file to append pull output to
+ * @returns {{status: number, error?: Error}} Spawn result (status = docker exit code)
+ */
+function runDockerPull(image, logPath) {
+  const { shellQuote } = require('./isolation-log-utils');
+
+  // Without a log target (or on Windows where tee is unreliable), keep the
+  // original inherited-stdio behavior for fancy real-time console output.
+  if (!logPath || process.platform === 'win32') {
+    return spawnSync('docker', ['pull', image], {
+      stdio: ['pipe', 'inherit', 'inherit'],
+    });
+  }
+
+  // Tee docker pull output to both the console and the log file. docker writes
+  // to a pipe here, so it emits plain progress lines (ideal for a log). The
+  // sentinel file captures docker's real exit code (the pipeline's own exit
+  // status would be tee's).
+  const statusFile = path.join(
+    os.tmpdir(),
+    `start-docker-pull-${process.pid}-${Date.now()}.status`
+  );
+  try {
+    const pipeline =
+      `{ docker pull ${shellQuote(image)} 2>&1; echo $? > ${shellQuote(statusFile)}; } ` +
+      `| tee -a ${shellQuote(logPath)}`;
+    const result = spawnSync('sh', ['-c', pipeline], {
+      stdio: ['pipe', 'inherit', 'inherit'],
+    });
+    if (result.error) {
+      return result;
+    }
+    let status = result.status;
+    try {
+      const recorded = fs.readFileSync(statusFile, 'utf8').trim();
+      if (recorded !== '') {
+        status = parseInt(recorded, 10);
+      }
+    } catch {
+      // Sentinel missing (e.g. sh/tee failed before docker ran); keep pipeline status.
+    }
+    return { ...result, status };
+  } finally {
+    try {
+      fs.unlinkSync(statusFile);
+    } catch {
+      // best-effort cleanup
+    }
+  }
+}
+
+/**
+ * Pull a Docker image with output streaming
+ * Displays the pull operation as a virtual command in the timeline.
+ *
+ * When a logPath is provided, the image-preparation phase (the `docker pull`)
+ * is also recorded in the session log so the single log file is a gap-free
+ * record of everything that ran (issue #138): a `Preparing image …` marker with
+ * a timestamp is written before the pull, the pull output is teed into the log,
+ * and an `Image ready (<duration>)` marker is written afterwards.
+ *
+ * @param {string} image - Docker image to pull
+ * @param {string|null} logPath - Optional session log file to append output to
  * @returns {{success: boolean, output: string}} Pull result
  */
-function dockerPullImage(image) {
+function dockerPullImage(image, logPath = null) {
   const {
     createVirtualCommandBlock,
     createVirtualCommandResult,
     createTimelineSeparator,
   } = require('./output-blocks');
+  const { appendLogFile, getTimestamp } = require('./isolation-log-utils');
 
   // Print the virtual command line followed by empty line for visual separation
   console.log(createVirtualCommandBlock(`docker pull ${image}`));
   console.log();
 
+  // Record the start of the image-preparation phase in the session log so
+  // operators tailing the log see progress instead of a header-only file.
+  const prepStartMs = Date.now();
+  if (logPath) {
+    appendLogFile(
+      logPath,
+      `$ docker pull ${image}\nPreparing image ${image}… (${getTimestamp()})\n`
+    );
+  }
+
   let output = '';
   let success;
 
   try {
-    // Run docker pull with inherited stdio for real-time output
-    const result = spawnSync('docker', ['pull', image], {
-      stdio: ['pipe', 'inherit', 'inherit'],
-    });
+    const result = runDockerPull(image, logPath);
+    if (result.error) {
+      throw result.error;
+    }
 
     success = result.status === 0;
 
@@ -140,6 +225,21 @@ function dockerPullImage(image) {
     console.error(`Failed to run docker pull: ${err.message}`);
     output = err.message;
     success = false;
+    if (logPath) {
+      appendLogFile(logPath, `Failed to run docker pull: ${err.message}\n`);
+    }
+  }
+
+  // Record the end of the image-preparation phase with elapsed duration so the
+  // prep time is visible even when full progress is unavailable (issue #138).
+  if (logPath) {
+    const durationSec = ((Date.now() - prepStartMs) / 1000).toFixed(1);
+    appendLogFile(
+      logPath,
+      success
+        ? `Image ready (${durationSec}s)\n`
+        : `Image preparation failed (${durationSec}s)\n`
+    );
   }
 
   // Print empty line before result marker for visual separation (issue #73)

--- a/js/src/lib/isolation.js
+++ b/js/src/lib/isolation.js
@@ -588,7 +588,9 @@ function runInDocker(command, options = {}) {
 
   const containerName = options.session || generateSessionName('docker');
   if (!dockerImageExists(options.image)) {
-    const pullResult = dockerPullImage(options.image);
+    // Pass logPath so the image-preparation phase (docker pull) is recorded in
+    // the session log, keeping it a gap-free record of the run (issue #138).
+    const pullResult = dockerPullImage(options.image, options.logPath);
     if (!pullResult.success) {
       return Promise.resolve({
         success: false,

--- a/js/test/regression-138.js
+++ b/js/test/regression-138.js
@@ -96,6 +96,14 @@ describe('docker pull is recorded in the session log (issue #138)', () => {
       console.log('  Skipping: docker daemon not available');
       return;
     }
+    if (process.platform === 'win32') {
+      // Windows Docker runners pull Linux images slowly/unreliably and the
+      // capture path is exercised by the failed-pull test above; skip to avoid
+      // network-dependent timeouts. The real-pull streaming path is Unix-only.
+      console.log = originalLog;
+      console.log('  Skipping: real pull is unreliable on Windows Docker');
+      return;
+    }
 
     // Use a tiny image and force a real pull by removing it first.
     const image = 'hello-world:latest';

--- a/js/test/regression-138.js
+++ b/js/test/regression-138.js
@@ -1,0 +1,191 @@
+#!/usr/bin/env bun
+/**
+ * Regression tests for issue #138:
+ * "Detached docker session log omits the image-preparation phase
+ *  (docker pull / dind boot) — $ does not preserve the full log in one file"
+ *
+ * When a command is launched with `--isolated docker`, the image-preparation
+ * phase (the `docker pull`) used to be printed to the console only and never
+ * written to the session log file. An operator tailing the session log (e.g.
+ * via `$ --upload-log <uuid>`) during a multi-GB pull would see only the
+ * header — the minutes spent pulling left no trace in the log.
+ *
+ * The fix tees the pull output into the session log and brackets it with
+ * `Preparing image …` / `Image ready (<duration>)` markers so the single
+ * session-log file is a gap-free record of everything that ran.
+ *
+ * Reference: https://github.com/link-foundation/start/issues/138
+ */
+
+const { describe, it, beforeEach, afterEach } = require('node:test');
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const {
+  dockerPullImage,
+  dockerImageExists,
+  isDockerAvailable,
+} = require('../src/lib/docker-utils');
+
+function makeTempLog() {
+  const logPath = path.join(
+    os.tmpdir(),
+    `start-138-${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2)}.log`
+  );
+  fs.writeFileSync(logPath, '=== Start Command Log ===\n');
+  return logPath;
+}
+
+describe('docker pull is recorded in the session log (issue #138)', () => {
+  // Silence the virtual-command console output during these tests.
+  let originalLog;
+  let originalError;
+  beforeEach(() => {
+    originalLog = console.log;
+    originalError = console.error;
+    console.log = () => {};
+    console.error = () => {};
+  });
+  afterEach(() => {
+    console.log = originalLog;
+    console.error = originalError;
+  });
+
+  it('writes prep markers and the docker error into the log on a failed pull', () => {
+    if (!isDockerAvailable()) {
+      console.log = originalLog;
+      console.log('  Skipping: docker daemon not available');
+      return;
+    }
+
+    const logPath = makeTempLog();
+    try {
+      // An invalid reference format fails fast without any network access.
+      const result = dockerPullImage('invalid..badname', logPath);
+      const contents = fs.readFileSync(logPath, 'utf8');
+
+      assert.strictEqual(
+        result.success,
+        false,
+        'pull of invalid ref must fail'
+      );
+      assert.ok(
+        contents.includes('Preparing image invalid..badname'),
+        'log must contain the "Preparing image …" start marker'
+      );
+      assert.ok(
+        contents.includes('Image preparation failed'),
+        'log must contain the failure marker with elapsed duration'
+      );
+      // The docker error itself (teed pull output) must be in the log, not just
+      // on the console — this is the core of issue #138.
+      assert.ok(
+        contents.includes('invalid reference format'),
+        'log must capture the teed docker pull error output'
+      );
+    } finally {
+      fs.rmSync(logPath, { force: true });
+    }
+  });
+
+  it('tees real pull output and an "Image ready" marker into the log', () => {
+    if (!isDockerAvailable()) {
+      console.log = originalLog;
+      console.log('  Skipping: docker daemon not available');
+      return;
+    }
+
+    // Use a tiny image and force a real pull by removing it first.
+    const image = 'hello-world:latest';
+    try {
+      require('child_process').execSync(`docker rmi ${image}`, {
+        stdio: ['pipe', 'pipe', 'pipe'],
+      });
+    } catch {
+      // image not present locally — that's fine, the pull below still runs
+    }
+
+    const logPath = makeTempLog();
+    try {
+      const result = dockerPullImage(image, logPath);
+      if (!result.success) {
+        // No network in this environment — cannot exercise the success path.
+        console.log = originalLog;
+        console.log('  Skipping: docker pull failed (no registry access?)');
+        return;
+      }
+
+      const contents = fs.readFileSync(logPath, 'utf8');
+      assert.ok(
+        contents.includes(`Preparing image ${image}`),
+        'log must contain the "Preparing image …" start marker'
+      );
+      assert.ok(
+        /Image ready \(\d+\.\d+s\)/.test(contents),
+        'log must contain "Image ready (<duration>)" marker'
+      );
+      assert.ok(
+        contents.includes('Pulling from') ||
+          contents.includes('Status:') ||
+          contents.includes('Pull complete'),
+        'log must capture the teed docker pull progress output'
+      );
+      assert.ok(
+        dockerImageExists(image),
+        'image should exist locally after a successful pull'
+      );
+    } finally {
+      fs.rmSync(logPath, { force: true });
+    }
+  });
+
+  it('does not write prep markers when no logPath is given (backward compat)', () => {
+    if (!isDockerAvailable()) {
+      console.log = originalLog;
+      console.log('  Skipping: docker daemon not available');
+      return;
+    }
+
+    // Without a logPath, dockerPullImage must still return the {success, output}
+    // shape and must not throw. We only assert the contract here.
+    const result = dockerPullImage('invalid..badname');
+    assert.strictEqual(result.success, false);
+    assert.strictEqual(typeof result.output, 'string');
+  });
+});
+
+describe('runInDocker threads logPath into dockerPullImage (issue #138)', () => {
+  it('source passes options.logPath to dockerPullImage', () => {
+    const isolationSrc = fs.readFileSync(
+      path.join(__dirname, '../src/lib/isolation.js'),
+      'utf8'
+    );
+    assert.ok(
+      /dockerPullImage\(options\.image,\s*options\.logPath\)/.test(
+        isolationSrc
+      ),
+      'runInDocker must pass options.logPath to dockerPullImage'
+    );
+  });
+
+  it('dockerPullImage tees output and writes prep markers in source', () => {
+    const dockerUtilsSrc = fs.readFileSync(
+      path.join(__dirname, '../src/lib/docker-utils.js'),
+      'utf8'
+    );
+    assert.ok(
+      dockerUtilsSrc.includes('Preparing image'),
+      'docker-utils must write a "Preparing image …" marker'
+    );
+    assert.ok(
+      dockerUtilsSrc.includes('Image ready'),
+      'docker-utils must write an "Image ready (<duration>)" marker'
+    );
+    assert.ok(
+      dockerUtilsSrc.includes('tee -a'),
+      'docker-utils must tee docker pull output into the log file'
+    );
+  });
+});

--- a/rust/changelog.d/138.md
+++ b/rust/changelog.d/138.md
@@ -1,0 +1,5 @@
+---
+bump: patch
+---
+
+Record the docker image-preparation phase in the session log (issue #138). When a `--isolated docker` run needs to `docker pull` an image, each line of pull output is now teed into the session-log file in real time and bracketed with `Preparing image <name>…` / `Image ready (<duration>)` markers (or `Image preparation failed` on error). Previously the time spent pulling a (potentially multi-GB) image left no trace in the log, so operators tailing the session log during startup saw only the header. The single session-log file is now a gap-free record of the run, including the longest, most failure-prone phase.

--- a/rust/src/lib/isolation.rs
+++ b/rust/src/lib/isolation.rs
@@ -558,9 +558,19 @@ pub fn docker_image_exists(image: &str) -> bool {
 }
 
 /// Pull a Docker image with output streaming
+///
+/// When `log_path` is provided, the image-preparation phase (the `docker pull`)
+/// is also recorded in the session log so the single log file is a gap-free
+/// record of everything that ran (issue #138): a `Preparing image …` marker with
+/// a timestamp is written before the pull, each line of pull output is teed into
+/// the log as it streams, and an `Image ready (<duration>)` marker is written
+/// afterwards. Without a `log_path` the behavior is unchanged.
+///
 /// Returns (success, output) tuple
-pub fn docker_pull_image(image: &str) -> (bool, String) {
+pub fn docker_pull_image(image: &str, log_path: Option<&PathBuf>) -> (bool, String) {
+    use crate::isolation::isolation_log::{append_log_file, get_timestamp};
     use std::io::{BufRead, BufReader};
+    use std::time::Instant;
 
     // Print the virtual command line followed by empty line for visual separation
     println!(
@@ -568,6 +578,21 @@ pub fn docker_pull_image(image: &str) -> (bool, String) {
         crate::output_blocks::create_virtual_command_block(&format!("docker pull {}", image))
     );
     println!();
+
+    // Record the start of the image-preparation phase in the session log so
+    // operators tailing the log see progress instead of a header-only file.
+    let prep_start = Instant::now();
+    if let Some(path) = log_path {
+        append_log_file(
+            path,
+            &format!(
+                "$ docker pull {}\nPreparing image {}… ({})\n",
+                image,
+                image,
+                get_timestamp()
+            ),
+        );
+    }
 
     let mut child = match Command::new("docker")
         .args(["pull", image])
@@ -579,6 +604,16 @@ pub fn docker_pull_image(image: &str) -> (bool, String) {
         Err(e) => {
             let error_msg = format!("Failed to run docker pull: {}", e);
             eprintln!("{}", error_msg);
+            if let Some(path) = log_path {
+                append_log_file(
+                    path,
+                    &format!(
+                        "{}\nImage preparation failed ({:.1}s)\n",
+                        error_msg,
+                        prep_start.elapsed().as_secs_f64()
+                    ),
+                );
+            }
             println!();
             println!(
                 "{}",
@@ -590,27 +625,47 @@ pub fn docker_pull_image(image: &str) -> (bool, String) {
 
     let mut output = String::new();
 
-    // Read and display stdout
+    // Read and display stdout, teeing each line into the session log.
     if let Some(stdout) = child.stdout.take() {
         let reader = BufReader::new(stdout);
         for line in reader.lines().map_while(Result::ok) {
             println!("{}", line);
+            if let Some(path) = log_path {
+                append_log_file(path, &format!("{}\n", line));
+            }
             output.push_str(&line);
             output.push('\n');
         }
     }
 
-    // Read and display stderr
+    // Read and display stderr, teeing each line into the session log.
     if let Some(stderr) = child.stderr.take() {
         let reader = BufReader::new(stderr);
         for line in reader.lines().map_while(Result::ok) {
             eprintln!("{}", line);
+            if let Some(path) = log_path {
+                append_log_file(path, &format!("{}\n", line));
+            }
             output.push_str(&line);
             output.push('\n');
         }
     }
 
     let success = child.wait().map(|s| s.success()).unwrap_or(false);
+
+    // Record the end of the image-preparation phase with elapsed duration so the
+    // prep time is visible even when full progress is unavailable (issue #138).
+    if let Some(path) = log_path {
+        let duration = prep_start.elapsed().as_secs_f64();
+        append_log_file(
+            path,
+            &if success {
+                format!("Image ready ({:.1}s)\n", duration)
+            } else {
+                format!("Image preparation failed ({:.1}s)\n", duration)
+            },
+        );
+    }
 
     // Print empty line before result marker for visual separation (issue #73)
     // This ensures output is visually separated from the result marker
@@ -670,9 +725,11 @@ pub fn run_in_docker(command: &str, options: &IsolationOptions) -> IsolationResu
         }
     };
 
-    // Check if image exists locally; if not, pull it as a virtual command
+    // Check if image exists locally; if not, pull it as a virtual command.
+    // Pass log_path so the image-preparation phase (docker pull) is recorded in
+    // the session log, keeping it a gap-free record of the run (issue #138).
     if !docker_image_exists(&image) {
-        let (pull_success, _pull_output) = docker_pull_image(&image);
+        let (pull_success, _pull_output) = docker_pull_image(&image, options.log_path.as_ref());
         if !pull_success {
             return IsolationResult {
                 success: false,

--- a/rust/tests/isolation.rs
+++ b/rust/tests/isolation.rs
@@ -2,7 +2,7 @@
 //!
 //! Tests for command isolation utilities and default Docker image detection.
 
-use start_command::get_default_docker_image;
+use start_command::{docker_pull_image, get_default_docker_image, is_command_available};
 
 #[test]
 fn test_get_default_docker_image() {
@@ -44,4 +44,56 @@ fn test_get_default_docker_image_returns_known_images() {
         image,
         known_images
     );
+}
+
+/// Regression test for issue #138: the image-preparation phase (docker pull)
+/// must be recorded in the session log. An invalid reference fails fast without
+/// any network access, so this exercises the marker + teed-output behavior even
+/// in environments without registry access.
+#[test]
+fn test_docker_pull_image_records_prep_phase_in_log() {
+    if !is_command_available("docker") {
+        eprintln!("  Skipping: docker not installed");
+        return;
+    }
+
+    let log_path = std::env::temp_dir().join(format!(
+        "start-138-rust-{}-{}.log",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0)
+    ));
+    std::fs::write(&log_path, "=== Start Command Log ===\n").unwrap();
+
+    let (success, _output) = docker_pull_image("invalid..badname", Some(&log_path));
+    let contents = std::fs::read_to_string(&log_path).unwrap();
+    let _ = std::fs::remove_file(&log_path);
+
+    assert!(!success, "pull of an invalid reference must fail");
+    assert!(
+        contents.contains("Preparing image invalid..badname"),
+        "log must contain the \"Preparing image …\" start marker, got:\n{}",
+        contents
+    );
+    assert!(
+        contents.contains("Image preparation failed"),
+        "log must contain the failure marker with elapsed duration, got:\n{}",
+        contents
+    );
+}
+
+/// Issue #138: without a log path, docker_pull_image must not panic and must
+/// return the (success, output) contract unchanged (backward compatibility).
+#[test]
+fn test_docker_pull_image_without_log_path() {
+    if !is_command_available("docker") {
+        eprintln!("  Skipping: docker not installed");
+        return;
+    }
+
+    let (success, output) = docker_pull_image("invalid..badname", None);
+    assert!(!success);
+    let _ = output; // output is a String; just ensure the call returns
 }


### PR DESCRIPTION
## Summary

Fixes #138 — the detached docker session log omitted the **image-preparation phase** (`docker pull`). Those minutes left no trace in `/tmp/start-command/logs/isolation/docker/<uuid>.log`, so an operator tailing `$ --upload-log <uuid>` during startup saw only the header.

The fix tees the `docker pull` output into the session log in real time and brackets it with timestamped markers, so the single session-log file is a gap-free record of everything that ran — including the longest, most failure-prone phase. The fix is applied to **both** the JS and Rust implementations for parity.

## What changed

### JS (`start-command`)
- **`js/src/lib/docker-utils.js`** — new `runDockerPull(image, logPath)` helper runs `docker pull` through a `sh` pipeline that tees output to **both** the console and the log file. docker's real exit code is recovered via a sentinel status file, because the exit status of a `cmd | tee` pipeline would otherwise be `tee`'s. `dockerPullImage(image, logPath = null)` now writes a `Preparing image <name>… (<timestamp>)` marker before the pull and an `Image ready (<duration>)` marker after (or `Image preparation failed` / the docker error on failure). Without a `logPath` the prior inherited-stdio behavior and return shape are unchanged. On Windows (no portable shell `tee`) but with a `logPath`, the pull output is captured, echoed to the console, and appended to the log after the pull — the log is still a gap-free record, just not streamed live.
- **`js/src/lib/isolation.js`** — `runInDocker` passes `options.logPath` into `dockerPullImage`.
- **`js/test/regression-138.js`** — new regression tests.

### Rust (`start-command` crate)
- **`rust/src/lib/isolation.rs`** — `docker_pull_image(image, log_path: Option<&PathBuf>)` tees each streamed line into the session log with the same markers; `run_in_docker` threads `options.log_path` through.
- **`rust/tests/isolation.rs`** — new regression tests.

### Release
- Changeset (`patch`) for JS and a `changelog.d/138.md` (`patch`) fragment for Rust.

## Before

`cat` of the session log jumped from the header straight to `Command started in detached docker container: …`, with the entire pull window unaccounted for.

## After

```
$ docker pull hello-world
Preparing image hello-world… (2026-06-19 10:01:57.522)
Using default tag: latest
latest: Pulling from library/hello-world
4f55086f7dd0: Pull complete
Status: Downloaded newer image for hello-world:latest
docker.io/library/hello-world:latest
Image ready (2.6s)
```

The dind-entrypoint boot lines were already captured (they come from `docker logs -f`, which replays from the container's first byte once it starts); the remaining gap was the pull, which this PR closes.

## Tests

- JS: `bun scripts/run-js-tests.mjs ./test/regression-138.js` → **5 pass** (failed pull markers + teed error, real-pull success path with `Image ready`, no-`logPath` backward-compat, source threading). Lint/format/file-size checks pass.
- Rust: `cargo test` → **all pass** (167 in the main suite + new isolation regressions). `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` clean.

The only failing existing JS tests in this sandbox (`isolation-cleanup`, `docker-autoremove`, keep-alive) fail identically on `main` and are unrelated to this change (nested-docker container-lifecycle quirks of the sandbox).

