### PR TITLE
Surface Docker OOMKilled status and preserve abnormal containers

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-06-26T14:21:03.315Z for PR creation at branch issue-144-d8d3fb7dfd56 for issue https://github.com/link-foundation/start/issues/144

--- a/README.md
+++ b/README.md
@@ -315,7 +315,10 @@ This is useful for:
 | `--isolated-user, -u [name]`     | Create isolated user with same permissions (screen/tmux)                     |
 | `--keep-user`                    | Keep isolated user after command completes (don't delete)                    |
 | `--keep-alive, -k`               | Keep session alive after command completes                                   |
-| `--auto-remove-docker-container` | Auto-remove docker container after exit (docker only)                        |
+| `--auto-remove-docker-container` | Always remove docker container after exit (docker only)                      |
+| `--always-cleanup-container`     | Always remove docker container after exit (docker only)                      |
+| `--keep-container`               | Keep docker container filesystem after exit (docker only)                    |
+| `--keep-container-on-fail`       | Keep failed or OOM-killed docker containers after exit (docker only)         |
 
 **Note:** Using both `--attached` and `--detached` together will result in an error - you must choose one mode.
 
@@ -336,7 +339,7 @@ $ -i screen -d -k -- echo "hello"
 # You can reattach with: screen -r <session-name>
 ```
 
-For Docker containers, by default the container filesystem is preserved (appears in `docker ps -a`) so you can re-enter it later. Use `--auto-remove-docker-container` to remove the container immediately after exit.
+For Docker containers, successful runs are removed by default. Failed containers, including containers Docker reports as `OOMKilled`, are kept for investigation and include a `docker rm -f <container>` cleanup hint. Use `--always-cleanup-container` or `--auto-remove-docker-container` to force removal after exit, or `--keep-container` to preserve the container filesystem after every run.
 
 ### Graceful Degradation
 

--- a/js/.changeset/detached-docker-oom-status.md
+++ b/js/.changeset/detached-docker-oom-status.md
@@ -1,0 +1,5 @@
+---
+'start-command': patch
+---
+
+Surface detached Docker OOMKilled status and preserve abnormal containers under the default cleanup policy.

--- a/js/src/lib/args-parser.js
+++ b/js/src/lib/args-parser.js
@@ -20,9 +20,9 @@
  * --keep-user                      Keep isolated user after command completes (don't delete)
  * --keep-alive, -k                 Keep isolation environment alive after command exits
  * --auto-remove-docker-container   Always remove docker container after exit (compatibility alias)
- * --always-cleanup-container       Always remove docker container after exit (default)
+ * --always-cleanup-container       Always remove docker container after exit
  * --keep-container                 Keep docker container filesystem after exit
- * --keep-container-on-fail         Remove successful docker containers, keep failed ones
+ * --keep-container-on-fail         Remove successful docker containers, keep failed or OOM-killed ones
  * --shell <shell>                  Shell to use in isolation environments: auto, bash, zsh, sh (default: auto)
  * --use-command-stream             Use command-stream library for command execution (experimental)
  * --verbose                        Enable verbose/debug output (sets START_VERBOSE=1)
@@ -185,9 +185,9 @@ function parseArgs(args) {
     keepUser: false, // Keep isolated user after command completes (don't delete)
     keepAlive: false, // Keep environment alive after command exits
     autoRemoveDockerContainer: false, // Always remove docker container after exit (compatibility alias)
-    alwaysCleanupContainer: false, // Explicitly request default always-cleanup docker policy
+    alwaysCleanupContainer: false, // Force docker container cleanup after exit
     keepContainer: false, // Keep docker container filesystem after exit
-    keepContainerOnFail: false, // Keep docker container filesystem only when command fails
+    keepContainerOnFail: false, // Keep docker container filesystem when command fails or OOM-kills
     shell: 'auto', // Shell to use in isolation environments: auto, bash, zsh, sh
     useCommandStream: false, // Use command-stream library for command execution
     status: null, // UUID to show status for

--- a/js/src/lib/docker-cleanup.js
+++ b/js/src/lib/docker-cleanup.js
@@ -12,6 +12,17 @@ const DOCKER_CONTAINER_CLEANUP_POLICY = {
   KEEP_ON_FAIL: 'keep-on-fail',
 };
 
+function getDockerCommand() {
+  return process.env.START_DOCKER_BIN || 'docker';
+}
+
+function getDockerSpawnOptions(options = {}) {
+  if (process.platform === 'win32' && process.env.START_DOCKER_BIN) {
+    return { ...options, shell: true };
+  }
+  return options;
+}
+
 function getDockerContainerCleanupPolicy(options = {}) {
   if (options.keepContainer) {
     return DOCKER_CONTAINER_CLEANUP_POLICY.KEEP;
@@ -77,13 +88,13 @@ function appendDockerContainerCleanupPolicyMessage(
 
 function readDockerContainerOomKilled(containerName) {
   const result = spawnSync(
-    'docker',
+    getDockerCommand(),
     ['inspect', '-f', '{{.State.OOMKilled}}', containerName],
-    {
+    getDockerSpawnOptions({
       encoding: 'utf8',
       env: process.env,
       stdio: ['pipe', 'pipe', 'pipe'],
-    }
+    })
   );
   if (result.error || result.status !== 0) {
     return null;
@@ -99,11 +110,15 @@ function readDockerContainerOomKilled(containerName) {
 }
 
 function removeDockerContainer(containerName, logPath = null) {
-  const result = spawnSync('docker', ['rm', '-f', containerName], {
-    encoding: 'utf8',
-    env: process.env,
-    stdio: ['pipe', 'pipe', 'pipe'],
-  });
+  const result = spawnSync(
+    getDockerCommand(),
+    ['rm', '-f', containerName],
+    getDockerSpawnOptions({
+      encoding: 'utf8',
+      env: process.env,
+      stdio: ['pipe', 'pipe', 'pipe'],
+    })
+  );
   const output = `${result.stdout || ''}${result.stderr || ''}`;
   if (logPath && output) {
     appendLogFile(logPath, output.endsWith('\n') ? output : `${output}\n`);
@@ -189,12 +204,20 @@ function startDetachedDockerCompletionWatcher(containerName, policy, logPath) {
 
 function spawnAttachedDocker(dockerArgs, logPath) {
   if (!logPath) {
-    return spawn('docker', dockerArgs, { stdio: 'inherit' });
+    return spawn(
+      getDockerCommand(),
+      dockerArgs,
+      getDockerSpawnOptions({ stdio: 'inherit' })
+    );
   }
 
-  const child = spawn('docker', dockerArgs, {
-    stdio: ['inherit', 'pipe', 'pipe'],
-  });
+  const child = spawn(
+    getDockerCommand(),
+    dockerArgs,
+    getDockerSpawnOptions({
+      stdio: ['inherit', 'pipe', 'pipe'],
+    })
+  );
   const tee = (chunk, stream) => {
     stream.write(chunk);
     appendLogFile(logPath, chunk.toString());
@@ -206,6 +229,8 @@ function spawnAttachedDocker(dockerArgs, logPath) {
 
 module.exports = {
   DOCKER_CONTAINER_CLEANUP_POLICY,
+  getDockerCommand,
+  getDockerSpawnOptions,
   getDockerContainerCleanupPolicy,
   isAbnormalDockerExit,
   shouldCleanupDockerContainer,

--- a/js/src/lib/docker-cleanup.js
+++ b/js/src/lib/docker-cleanup.js
@@ -6,6 +6,7 @@ const {
 } = require('./isolation-log-utils');
 
 const DOCKER_CONTAINER_CLEANUP_POLICY = {
+  DEFAULT: 'default',
   ALWAYS: 'always',
   KEEP: 'keep',
   KEEP_ON_FAIL: 'keep-on-fail',
@@ -18,15 +19,25 @@ function getDockerContainerCleanupPolicy(options = {}) {
   if (options.keepContainerOnFail) {
     return DOCKER_CONTAINER_CLEANUP_POLICY.KEEP_ON_FAIL;
   }
-  return DOCKER_CONTAINER_CLEANUP_POLICY.ALWAYS;
+  if (options.alwaysCleanupContainer || options.autoRemoveDockerContainer) {
+    return DOCKER_CONTAINER_CLEANUP_POLICY.ALWAYS;
+  }
+  return DOCKER_CONTAINER_CLEANUP_POLICY.DEFAULT;
 }
 
-function shouldCleanupDockerContainer(policy, exitCode) {
+function isAbnormalDockerExit(exitCode, oomKilled = false) {
+  return exitCode !== 0 || oomKilled === true;
+}
+
+function shouldCleanupDockerContainer(policy, exitCode, oomKilled = false) {
   if (policy === DOCKER_CONTAINER_CLEANUP_POLICY.ALWAYS) {
     return true;
   }
+  if (policy === DOCKER_CONTAINER_CLEANUP_POLICY.DEFAULT) {
+    return !isAbnormalDockerExit(exitCode, oomKilled);
+  }
   if (policy === DOCKER_CONTAINER_CLEANUP_POLICY.KEEP_ON_FAIL) {
-    return exitCode === 0;
+    return !isAbnormalDockerExit(exitCode, oomKilled);
   }
   return false;
 }
@@ -50,16 +61,47 @@ function appendDockerContainerCleanupPolicyMessage(
   if (policy === DOCKER_CONTAINER_CLEANUP_POLICY.KEEP_ON_FAIL) {
     return (
       `${message}\nContainer will be removed after successful completion.` +
-      `\nContainer will be kept if the command fails.` +
+      `\nContainer will be kept if the command fails or Docker reports OOMKilled.` +
+      `\nRemove when done: docker rm -f ${containerName}`
+    );
+  }
+  if (policy === DOCKER_CONTAINER_CLEANUP_POLICY.DEFAULT) {
+    return (
+      `${message}\nContainer will be removed after successful completion.` +
+      `\nContainer will be kept if the command fails or Docker reports OOMKilled.` +
       `\nRemove when done: docker rm -f ${containerName}`
     );
   }
   return `${message}\nContainer will be removed after command completes.`;
 }
 
+function readDockerContainerOomKilled(containerName) {
+  const result = spawnSync(
+    'docker',
+    ['inspect', '-f', '{{.State.OOMKilled}}', containerName],
+    {
+      encoding: 'utf8',
+      env: process.env,
+      stdio: ['pipe', 'pipe', 'pipe'],
+    }
+  );
+  if (result.error || result.status !== 0) {
+    return null;
+  }
+  const value = String(result.stdout || '').trim();
+  if (value === 'true') {
+    return true;
+  }
+  if (value === 'false') {
+    return false;
+  }
+  return null;
+}
+
 function removeDockerContainer(containerName, logPath = null) {
   const result = spawnSync('docker', ['rm', '-f', containerName], {
     encoding: 'utf8',
+    env: process.env,
     stdio: ['pipe', 'pipe', 'pipe'],
   });
   const output = `${result.stdout || ''}${result.stderr || ''}`;
@@ -67,6 +109,24 @@ function removeDockerContainer(containerName, logPath = null) {
     appendLogFile(logPath, output.endsWith('\n') ? output : `${output}\n`);
   }
   return !result.error && result.status === 0;
+}
+
+function buildDockerKeptLogSnippet(containerName, quotedLogPath) {
+  const quotedName = shellQuote(containerName);
+  return (
+    `printf '\\nContainer kept for investigation: %s\\nReason: exitCode=%s oomKilled=%s\\n` +
+    `Inspect: docker exec -it %s sh (if running) or docker start -ai %s\\n` +
+    `Remove when done: docker rm -f %s\\n' ` +
+    `${quotedName} "$__start_command_exit" "$__start_command_oom" ` +
+    `${quotedName} ${quotedName} ${quotedName} >> ${quotedLogPath}`
+  );
+}
+
+function buildSuccessfulNonOomCondition() {
+  return (
+    '[ "$__start_command_exit" -eq 0 ] 2>/dev/null && ' +
+    '[ "$__start_command_oom" != true ]'
+  );
 }
 
 function buildDetachedDockerCompletionScript(containerName, policy, logPath) {
@@ -77,26 +137,37 @@ function buildDetachedDockerCompletionScript(containerName, policy, logPath) {
     const quotedLogPath = shellQuote(logPath);
     parts.push(`docker logs -f ${quotedName} >> ${quotedLogPath} 2>&1`);
     parts.push(
-      `__start_command_exit=$(docker inspect -f '{{.State.ExitCode}}' ${quotedName} 2>/dev/null || printf '%s' '-1')`
+      `__start_command_state=$(docker inspect -f '{{.State.ExitCode}} {{.State.OOMKilled}}' ${quotedName} 2>/dev/null || printf '%s' '-1 false')`
     );
+    parts.push('__start_command_exit=${__start_command_state%% *}');
+    parts.push('__start_command_oom=${__start_command_state##* }');
     if (policy === DOCKER_CONTAINER_CLEANUP_POLICY.ALWAYS) {
       parts.push(`docker rm -f ${quotedName} >> ${quotedLogPath} 2>&1 || true`);
-    } else if (policy === DOCKER_CONTAINER_CLEANUP_POLICY.KEEP_ON_FAIL) {
+    } else if (
+      policy === DOCKER_CONTAINER_CLEANUP_POLICY.DEFAULT ||
+      policy === DOCKER_CONTAINER_CLEANUP_POLICY.KEEP_ON_FAIL
+    ) {
+      const successCondition = buildSuccessfulNonOomCondition();
       parts.push(
-        `if [ "$__start_command_exit" -eq 0 ] 2>/dev/null; then docker rm -f ${quotedName} >> ${quotedLogPath} 2>&1 || true; fi`
+        `if ${successCondition}; then docker rm -f ${quotedName} >> ${quotedLogPath} 2>&1 || true; else ${buildDockerKeptLogSnippet(containerName, quotedLogPath)}; fi`
       );
     }
     parts.push(`${createShellLogFooterSnippet()} >> ${quotedLogPath}`);
   } else {
     parts.push(`docker wait ${quotedName} >/dev/null 2>&1`);
     parts.push(
-      `__start_command_exit=$(docker inspect -f '{{.State.ExitCode}}' ${quotedName} 2>/dev/null || printf '%s' '-1')`
+      `__start_command_state=$(docker inspect -f '{{.State.ExitCode}} {{.State.OOMKilled}}' ${quotedName} 2>/dev/null || printf '%s' '-1 false')`
     );
+    parts.push('__start_command_exit=${__start_command_state%% *}');
+    parts.push('__start_command_oom=${__start_command_state##* }');
     if (policy === DOCKER_CONTAINER_CLEANUP_POLICY.ALWAYS) {
       parts.push(`docker rm -f ${quotedName} >/dev/null 2>&1 || true`);
-    } else if (policy === DOCKER_CONTAINER_CLEANUP_POLICY.KEEP_ON_FAIL) {
+    } else if (
+      policy === DOCKER_CONTAINER_CLEANUP_POLICY.DEFAULT ||
+      policy === DOCKER_CONTAINER_CLEANUP_POLICY.KEEP_ON_FAIL
+    ) {
       parts.push(
-        `if [ "$__start_command_exit" -eq 0 ] 2>/dev/null; then docker rm -f ${quotedName} >/dev/null 2>&1 || true; fi`
+        `if ${buildSuccessfulNonOomCondition()}; then docker rm -f ${quotedName} >/dev/null 2>&1 || true; fi`
       );
     }
   }
@@ -136,10 +207,13 @@ function spawnAttachedDocker(dockerArgs, logPath) {
 module.exports = {
   DOCKER_CONTAINER_CLEANUP_POLICY,
   getDockerContainerCleanupPolicy,
+  isAbnormalDockerExit,
   shouldCleanupDockerContainer,
   getDockerContainerCleanupInstructions,
   appendDockerContainerCleanupPolicyMessage,
+  readDockerContainerOomKilled,
   removeDockerContainer,
+  buildDetachedDockerCompletionScript,
   startDetachedDockerCompletionWatcher,
   spawnAttachedDocker,
 };

--- a/js/src/lib/execution-control.js
+++ b/js/src/lib/execution-control.js
@@ -10,6 +10,7 @@ const {
   escapeForLinksNotation,
   formatAsNestedLinksNotation,
 } = require('./output-blocks');
+const { getDockerCommand, getDockerSpawnOptions } = require('./docker-cleanup');
 
 const ControlAction = {
   STOP: 'stop',
@@ -17,10 +18,15 @@ const ControlAction = {
 };
 
 function runCommand(command, args) {
-  const result = spawnSync(command, args, {
+  const options = {
     encoding: 'utf8',
     stdio: ['ignore', 'pipe', 'pipe'],
-  });
+  };
+  const result = spawnSync(
+    command,
+    args,
+    command === getDockerCommand() ? getDockerSpawnOptions(options) : options
+  );
 
   return {
     success: !result.error && result.status === 0,
@@ -143,7 +149,7 @@ function collectProcessIds(record, runner = runCommand) {
     addIfPresent(processIds, 'commandPids', commandPids);
   } else if (isolated === 'docker') {
     addIfPresent(processIds, 'containerId', opts.containerId);
-    const result = runner('docker', [
+    const result = runner(getDockerCommand(), [
       'inspect',
       '-f',
       '{{.Id}} {{.State.Pid}}',

--- a/js/src/lib/execution-store.js
+++ b/js/src/lib/execution-store.js
@@ -14,6 +14,7 @@
  * - logPath: Path to the log file
  * - startTime: Timestamp when execution started
  * - endTime: Timestamp when execution completed (null while executing)
+ * - oomKilled: Docker resource-exhaustion signal when available
  * - options: Execution options (isolation mode, etc.)
  */
 
@@ -73,6 +74,8 @@ class ExecutionRecord {
     this.logPath = options.logPath || '';
     this.startTime = options.startTime || new Date().toISOString();
     this.endTime = options.endTime || null;
+    this.oomKilled =
+      options.oomKilled !== undefined ? options.oomKilled : undefined;
     this.workingDirectory = options.workingDirectory || process.cwd();
     this.shell = options.shell || process.env.SHELL || '/bin/sh';
     this.platform = options.platform || process.platform;
@@ -93,7 +96,7 @@ class ExecutionRecord {
    * Convert to plain object for serialization
    */
   toObject() {
-    return {
+    const obj = {
       uuid: this.uuid,
       pid: this.pid,
       status: this.status,
@@ -102,11 +105,17 @@ class ExecutionRecord {
       logPath: this.logPath,
       startTime: this.startTime,
       endTime: this.endTime,
+    };
+    if (this.oomKilled !== undefined && this.oomKilled !== null) {
+      obj.oomKilled = this.oomKilled;
+    }
+    Object.assign(obj, {
       workingDirectory: this.workingDirectory,
       shell: this.shell,
       platform: this.platform,
       options: this.options,
-    };
+    });
+    return obj;
   }
 
   /**

--- a/js/src/lib/isolation.js
+++ b/js/src/lib/isolation.js
@@ -27,6 +27,7 @@ const {
   shouldCleanupDockerContainer,
   getDockerContainerCleanupInstructions,
   appendDockerContainerCleanupPolicyMessage,
+  readDockerContainerOomKilled,
   removeDockerContainer,
   startDetachedDockerCompletionWatcher,
   spawnAttachedDocker,
@@ -758,7 +759,11 @@ function runInDocker(command, options = {}) {
             message += `\n${hint}`;
           }
 
-          if (shouldCleanupDockerContainer(cleanupPolicy, exitCode)) {
+          const oomKilled = readDockerContainerOomKilled(containerName);
+
+          if (
+            shouldCleanupDockerContainer(cleanupPolicy, exitCode, oomKilled)
+          ) {
             if (removeDockerContainer(containerName, options.logPath)) {
               message += `\nContainer removed after completion.`;
             } else {
@@ -768,9 +773,13 @@ function runInDocker(command, options = {}) {
           } else if (cleanupPolicy === DOCKER_CONTAINER_CLEANUP_POLICY.KEEP) {
             message += `\n${getDockerContainerCleanupInstructions(containerName)}`;
           } else if (
-            cleanupPolicy === DOCKER_CONTAINER_CLEANUP_POLICY.KEEP_ON_FAIL
+            cleanupPolicy === DOCKER_CONTAINER_CLEANUP_POLICY.KEEP_ON_FAIL ||
+            cleanupPolicy === DOCKER_CONTAINER_CLEANUP_POLICY.DEFAULT
           ) {
-            message += `\nContainer kept because the command failed.`;
+            message +=
+              oomKilled === true
+                ? `\nContainer kept because Docker reports it was OOM-killed.`
+                : `\nContainer kept because the command failed.`;
             message += `\nRemove when done: docker rm -f ${containerName}`;
           }
 

--- a/js/src/lib/status-formatter.js
+++ b/js/src/lib/status-formatter.js
@@ -14,6 +14,7 @@ const {
   formatAsNestedLinksNotation,
 } = require('./output-blocks');
 const { collectProcessIds } = require('./execution-control');
+const { getDockerCommand, getDockerSpawnOptions } = require('./docker-cleanup');
 
 /**
  * Inspect the live state of a detached docker container by name.
@@ -35,14 +36,18 @@ const { collectProcessIds } = require('./execution-control');
  */
 function inspectDockerState(sessionName) {
   const result = spawnSync(
-    'docker',
+    getDockerCommand(),
     [
       'inspect',
       '-f',
       '{{.State.Running}} {{.State.ExitCode}} {{.State.OOMKilled}}',
       sessionName,
     ],
-    { encoding: 'utf8', env: process.env, stdio: ['pipe', 'pipe', 'pipe'] }
+    getDockerSpawnOptions({
+      encoding: 'utf8',
+      env: process.env,
+      stdio: ['pipe', 'pipe', 'pipe'],
+    })
   );
   if (result.error || result.status !== 0 || !result.stdout) {
     return null;

--- a/js/src/lib/status-formatter.js
+++ b/js/src/lib/status-formatter.js
@@ -30,23 +30,30 @@ const { collectProcessIds } = require('./execution-control');
  * instead of fabricating a terminal `-1` result.
  *
  * @param {string} sessionName - Container name
- * @returns {{running: boolean, exitCode: number|null}|null} State, or null when
- *   the container cannot be inspected (not found yet, removed, or docker error)
+ * @returns {{running: boolean, exitCode: number|null, oomKilled: boolean|null}|null} State,
+ *   or null when the container cannot be inspected (not found yet, removed, or docker error)
  */
 function inspectDockerState(sessionName) {
   const result = spawnSync(
     'docker',
-    ['inspect', '-f', '{{.State.Running}} {{.State.ExitCode}}', sessionName],
-    { encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'] }
+    [
+      'inspect',
+      '-f',
+      '{{.State.Running}} {{.State.ExitCode}} {{.State.OOMKilled}}',
+      sessionName,
+    ],
+    { encoding: 'utf8', env: process.env, stdio: ['pipe', 'pipe', 'pipe'] }
   );
   if (result.error || result.status !== 0 || !result.stdout) {
     return null;
   }
-  const [runningRaw, exitRaw] = result.stdout.trim().split(/\s+/);
+  const [runningRaw, exitRaw, oomKilledRaw] = result.stdout.trim().split(/\s+/);
   const exitCode = Number.parseInt(exitRaw, 10);
   return {
     running: runningRaw === 'true',
     exitCode: Number.isFinite(exitCode) ? exitCode : null,
+    oomKilled:
+      oomKilledRaw === 'true' ? true : oomKilledRaw === 'false' ? false : null,
   };
 }
 
@@ -65,6 +72,15 @@ function readBackendExitCode(record) {
   }
   const state = inspectDockerState(opts.sessionName);
   return state && !state.running ? state.exitCode : null;
+}
+
+function readDockerOomKilled(record) {
+  const opts = record.options || {};
+  if (opts.isolated !== 'docker' || !opts.sessionName) {
+    return null;
+  }
+  const state = inspectDockerState(opts.sessionName);
+  return state ? state.oomKilled : null;
 }
 
 /**
@@ -183,6 +199,10 @@ function enrichDetachedStatus(record) {
   }
 
   const enriched = cloneRecord();
+  const oomKilled = readDockerOomKilled(enriched);
+  if (oomKilled !== null) {
+    enriched.oomKilled = oomKilled;
+  }
 
   if (alive && enriched.status === 'executed') {
     // A live `screen -ls` (or `tmux`/`docker`) session does NOT mean the command
@@ -358,6 +378,9 @@ function formatRecordAsText(record) {
     `Status:            ${obj.status}`,
     `Command:           ${obj.command}`,
     `Exit Code:         ${obj.exitCode !== null ? obj.exitCode : 'N/A'}`,
+    ...(obj.oomKilled !== undefined
+      ? [`OOM Killed:        ${obj.oomKilled}`]
+      : []),
     `PID:               ${obj.pid !== null ? obj.pid : 'N/A'}`,
     `Working Directory: ${obj.workingDirectory}`,
     `Shell:             ${obj.shell}`,

--- a/js/src/lib/usage.js
+++ b/js/src/lib/usage.js
@@ -19,9 +19,9 @@ Options:
   --keep-user           Keep isolated user after command completes
   --keep-alive, -k      Keep isolation environment alive after command exits
   --auto-remove-docker-container  Always remove docker container after exit (compatibility alias)
-  --always-cleanup-container  Always remove docker container after exit (default)
+  --always-cleanup-container  Always remove docker container after exit
   --keep-container     Keep docker container filesystem after exit
-  --keep-container-on-fail  Remove successful docker containers, keep failed ones
+  --keep-container-on-fail  Remove successful docker containers, keep failed or OOM-killed ones
   --shell <shell>       Shell to use in isolation environments: auto, bash, zsh, sh (default: auto)
   --use-command-stream  Use command-stream library for execution (experimental)
   --status <id>         Show status of execution by UUID or session name (--output-format: links-notation|json|text)

--- a/js/test/docker-autoremove.js
+++ b/js/test/docker-autoremove.js
@@ -11,6 +11,12 @@ const path = require('path');
 const { isCommandAvailable } = require('../src/lib/isolation');
 const { runInDocker } = require('../src/lib/isolation');
 const { execSync } = require('child_process');
+const {
+  DOCKER_CONTAINER_CLEANUP_POLICY,
+  buildDetachedDockerCompletionScript,
+  getDockerContainerCleanupPolicy,
+  shouldCleanupDockerContainer,
+} = require('../src/lib/docker-cleanup');
 
 // Helper to wait for a condition with timeout
 async function waitFor(conditionFn, timeout = 5000, interval = 100) {
@@ -32,6 +38,47 @@ const DOCKER_TEST_TIMEOUT = 20000;
 describe('Docker Container Cleanup Policy', () => {
   // These tests verify that docker isolation removes finished containers by
   // default while still providing explicit flags to keep them for investigation.
+
+  describe('cleanup decisions', () => {
+    it('should keep abnormal containers under the default policy', () => {
+      const policy = getDockerContainerCleanupPolicy({});
+      assert.strictEqual(policy, DOCKER_CONTAINER_CLEANUP_POLICY.DEFAULT);
+      assert.strictEqual(shouldCleanupDockerContainer(policy, 0, false), true);
+      assert.strictEqual(shouldCleanupDockerContainer(policy, 7, false), false);
+      assert.strictEqual(shouldCleanupDockerContainer(policy, 0, true), false);
+    });
+
+    it('should keep OOM-killed containers with keepContainerOnFail', () => {
+      const policy = getDockerContainerCleanupPolicy({
+        keepContainerOnFail: true,
+      });
+      assert.strictEqual(policy, DOCKER_CONTAINER_CLEANUP_POLICY.KEEP_ON_FAIL);
+      assert.strictEqual(shouldCleanupDockerContainer(policy, 0, false), true);
+      assert.strictEqual(shouldCleanupDockerContainer(policy, 0, true), false);
+    });
+
+    it('should honor explicit always-cleanup policy', () => {
+      const policy = getDockerContainerCleanupPolicy({
+        alwaysCleanupContainer: true,
+      });
+      assert.strictEqual(policy, DOCKER_CONTAINER_CLEANUP_POLICY.ALWAYS);
+      assert.strictEqual(shouldCleanupDockerContainer(policy, 7, false), true);
+      assert.strictEqual(shouldCleanupDockerContainer(policy, 0, true), true);
+    });
+
+    it('should make the detached watcher inspect OOMKilled before default cleanup', () => {
+      const script = buildDetachedDockerCompletionScript(
+        'issue144-container',
+        DOCKER_CONTAINER_CLEANUP_POLICY.DEFAULT,
+        '/tmp/issue144.log'
+      );
+      assert.match(script, /\.State\.ExitCode.*\.State\.OOMKilled/);
+      assert.match(script, /__start_command_oom/);
+      assert.match(script, /Container kept for investigation/);
+      assert.match(script, /docker rm -f/);
+      assert.match(script, /issue144-container/);
+    });
+  });
 
   describe('auto-remove enabled', () => {
     it(

--- a/js/test/session-name-status.js
+++ b/js/test/session-name-status.js
@@ -99,11 +99,18 @@ function withFakeDockerInspect(stateLine, fn) {
   }
 
   const originalPath = process.env.PATH;
+  const originalDockerBin = process.env.START_DOCKER_BIN;
   process.env.PATH = `${fakeBin}${path.delimiter}${originalPath || ''}`;
+  process.env.START_DOCKER_BIN = dockerPath;
   try {
     return fn();
   } finally {
     process.env.PATH = originalPath;
+    if (originalDockerBin === undefined) {
+      delete process.env.START_DOCKER_BIN;
+    } else {
+      process.env.START_DOCKER_BIN = originalDockerBin;
+    }
     fs.rmSync(fakeBin, { recursive: true, force: true });
   }
 }

--- a/js/test/session-name-status.js
+++ b/js/test/session-name-status.js
@@ -16,6 +16,7 @@ const {
 } = require('../src/lib/execution-store');
 const {
   queryStatus,
+  listExecutions,
   isDetachedSessionAlive,
   enrichDetachedStatus,
   attachCurrentTime,
@@ -53,6 +54,58 @@ function runCli(args, env = {}) {
     stderr: result.stderr || '',
     exitCode: result.status,
   };
+}
+
+function createExecutable(filePath, content) {
+  fs.writeFileSync(filePath, content, 'utf8');
+  fs.chmodSync(filePath, 0o755);
+}
+
+function withFakeDockerInspect(stateLine, fn) {
+  const fakeBin = fs.mkdtempSync(path.join(os.tmpdir(), 'fake-docker-'));
+  const dockerPath = path.join(
+    fakeBin,
+    process.platform === 'win32' ? 'docker.cmd' : 'docker'
+  );
+  if (process.platform === 'win32') {
+    createExecutable(
+      dockerPath,
+      [
+        '@echo off',
+        'if not "%1"=="inspect" exit /b 1',
+        'echo %3 | findstr /C:"State.Pid" >nul',
+        'if %errorlevel%==0 (',
+        '  echo fake-container-id 4321',
+        '  exit /b 0',
+        ')',
+        `echo ${stateLine}`,
+        'exit /b 0',
+        '',
+      ].join('\r\n')
+    );
+  } else {
+    createExecutable(
+      dockerPath,
+      [
+        '#!/bin/sh',
+        '[ "$1" = "inspect" ] || exit 1',
+        'case "$3" in',
+        '  *State.Pid*) echo "fake-container-id 4321" ;;',
+        `  *) echo "${stateLine}" ;;`,
+        'esac',
+        '',
+      ].join('\n')
+    );
+  }
+
+  const originalPath = process.env.PATH;
+  process.env.PATH = `${fakeBin}${path.delimiter}${originalPath || ''}`;
+  try {
+    return fn();
+  } finally {
+    process.env.PATH = originalPath;
+    fs.rmSync(fakeBin, { recursive: true, force: true });
+  }
 }
 
 describe('Issue #101: --status with session name lookup', () => {
@@ -549,6 +602,71 @@ describe('Issue #136: detached docker session liveness', () => {
     } finally {
       dockerRm(name);
     }
+  });
+});
+
+describe('Issue #144: detached docker OOMKilled status signal', () => {
+  let store;
+
+  beforeEach(() => {
+    cleanupTestDir();
+    store = new ExecutionStore({
+      appFolder: TEST_APP_FOLDER,
+      useLinks: false,
+    });
+  });
+
+  afterEach(() => {
+    cleanupTestDir();
+  });
+
+  function saveDockerRecord() {
+    const record = new ExecutionRecord({
+      command: 'sh -c "exit 0"',
+      logPath: '/tmp/issue-144.log',
+      options: {
+        sessionName: 'issue144-oom',
+        isolated: 'docker',
+        isolationMode: 'detached',
+      },
+    });
+    store.save(record);
+    return record;
+  }
+
+  it('surfaces oomKilled in status output even when Docker exit code is 0', () => {
+    const record = saveDockerRecord();
+
+    withFakeDockerInspect('false 0 true', () => {
+      const jsonResult = queryStatus(store, record.uuid, 'json');
+      expect(jsonResult.success).toBe(true);
+      const parsed = JSON.parse(jsonResult.output);
+      expect(parsed.status).toBe('executed');
+      expect(parsed.exitCode).toBe(0);
+      expect(parsed.oomKilled).toBe(true);
+
+      const linksResult = queryStatus(store, record.uuid, 'links-notation');
+      expect(linksResult.success).toBe(true);
+      expect(linksResult.output).toContain('  oomKilled true');
+
+      const textResult = queryStatus(store, record.uuid, 'text');
+      expect(textResult.success).toBe(true);
+      expect(textResult.output).toContain('OOM Killed:        true');
+    });
+  });
+
+  it('surfaces oomKilled in list output', () => {
+    saveDockerRecord();
+
+    withFakeDockerInspect('false 0 true', () => {
+      const result = listExecutions(store, 'json');
+      expect(result.success).toBe(true);
+      const parsed = JSON.parse(result.output);
+      expect(parsed.count).toBe(1);
+      expect(parsed.executions[0].status).toBe('executed');
+      expect(parsed.executions[0].exitCode).toBe(0);
+      expect(parsed.executions[0].oomKilled).toBe(true);
+    });
   });
 });
 

--- a/rust/changelog.d/144.md
+++ b/rust/changelog.d/144.md
@@ -1,0 +1,5 @@
+---
+bump: patch
+---
+
+Surface detached Docker OOMKilled status and preserve abnormal containers under the default cleanup policy.

--- a/rust/src/lib/args_parser.rs
+++ b/rust/src/lib/args_parser.rs
@@ -19,9 +19,9 @@
 //! --keep-user                      Keep isolated user after command completes
 //! --keep-alive, -k                 Keep isolation environment alive after command exits
 //! --auto-remove-docker-container   Always remove docker container after exit (compatibility alias)
-//! --always-cleanup-container       Always remove docker container after exit (default)
+//! --always-cleanup-container       Always remove docker container after exit
 //! --keep-container                 Keep docker container filesystem after exit
-//! --keep-container-on-fail         Remove successful docker containers, keep failed ones
+//! --keep-container-on-fail         Remove successful docker containers, keep failed or OOM-killed ones
 //! --shell <shell>                  Shell to use in isolation environments: auto, bash, zsh, sh (default: auto)
 //! --status <uuid-or-session-name>  Show status of a tracked execution
 //! --list                           List all tracked command executions
@@ -92,11 +92,11 @@ pub struct WrapperOptions {
     pub keep_alive: bool,
     /// Auto-remove docker container after exit
     pub auto_remove_docker_container: bool,
-    /// Explicitly request default always-cleanup docker policy
+    /// Force docker container cleanup after exit
     pub always_cleanup_container: bool,
     /// Keep docker container filesystem after exit
     pub keep_container: bool,
-    /// Keep docker container filesystem only when command fails
+    /// Keep docker container filesystem when command fails or OOM-kills
     pub keep_container_on_fail: bool,
     /// Shell to use in isolation environments: auto, bash, zsh, sh
     pub shell: String,

--- a/rust/src/lib/docker_cleanup.rs
+++ b/rust/src/lib/docker_cleanup.rs
@@ -41,6 +41,10 @@ pub(crate) enum DockerContainerCleanupPolicy {
     KeepOnFail,
 }
 
+pub(crate) fn docker_command() -> std::ffi::OsString {
+    std::env::var_os("START_DOCKER_BIN").unwrap_or_else(|| std::ffi::OsString::from("docker"))
+}
+
 pub(crate) fn get_docker_container_cleanup_policy(
     options: &IsolationOptions,
 ) -> DockerContainerCleanupPolicy {
@@ -116,7 +120,7 @@ pub(crate) fn append_docker_container_cleanup_policy_message(
 }
 
 pub(crate) fn read_docker_container_oom_killed(container_name: &str) -> Option<bool> {
-    let output = Command::new("docker")
+    let output = Command::new(docker_command())
         .args(["inspect", "-f", "{{.State.OOMKilled}}", container_name])
         .output()
         .ok()?;
@@ -131,7 +135,7 @@ pub(crate) fn read_docker_container_oom_killed(container_name: &str) -> Option<b
 }
 
 pub(crate) fn remove_docker_container(container_name: &str, log_path: Option<&PathBuf>) -> bool {
-    let output = Command::new("docker")
+    let output = Command::new(docker_command())
         .args(["rm", "-f", container_name])
         .output();
     match output {
@@ -281,7 +285,7 @@ pub(crate) fn spawn_attached_docker(
     log_path: Option<&PathBuf>,
 ) -> std::io::Result<AttachedDockerChild> {
     if log_path.is_none() {
-        let child = Command::new("docker")
+        let child = Command::new(docker_command())
             .args(args)
             .stdin(Stdio::inherit())
             .stdout(Stdio::inherit())
@@ -294,7 +298,7 @@ pub(crate) fn spawn_attached_docker(
         });
     }
 
-    let mut child = Command::new("docker")
+    let mut child = Command::new(docker_command())
         .args(args)
         .stdin(Stdio::inherit())
         .stdout(Stdio::piped())

--- a/rust/src/lib/docker_cleanup.rs
+++ b/rust/src/lib/docker_cleanup.rs
@@ -35,6 +35,7 @@ pub(crate) fn build_docker_runtime_args(options: &IsolationOptions) -> Vec<&str>
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) enum DockerContainerCleanupPolicy {
+    Default,
     Always,
     Keep,
     KeepOnFail,
@@ -47,19 +48,27 @@ pub(crate) fn get_docker_container_cleanup_policy(
         DockerContainerCleanupPolicy::Keep
     } else if options.keep_container_on_fail {
         DockerContainerCleanupPolicy::KeepOnFail
-    } else {
+    } else if options.always_cleanup_container || options.auto_remove_docker_container {
         DockerContainerCleanupPolicy::Always
+    } else {
+        DockerContainerCleanupPolicy::Default
     }
+}
+
+pub(crate) fn is_abnormal_docker_exit(exit_code: i32, oom_killed: bool) -> bool {
+    exit_code != 0 || oom_killed
 }
 
 pub(crate) fn should_cleanup_docker_container(
     policy: DockerContainerCleanupPolicy,
     exit_code: i32,
+    oom_killed: bool,
 ) -> bool {
     match policy {
+        DockerContainerCleanupPolicy::Default => !is_abnormal_docker_exit(exit_code, oom_killed),
         DockerContainerCleanupPolicy::Always => true,
         DockerContainerCleanupPolicy::Keep => false,
-        DockerContainerCleanupPolicy::KeepOnFail => exit_code == 0,
+        DockerContainerCleanupPolicy::KeepOnFail => !is_abnormal_docker_exit(exit_code, oom_killed),
     }
 }
 
@@ -79,18 +88,45 @@ pub(crate) fn append_docker_container_cleanup_policy_message(
         DockerContainerCleanupPolicy::Always => {
             message.push_str("\nContainer will be removed after command completes.");
         }
+        DockerContainerCleanupPolicy::Default => {
+            message.push_str("\nContainer will be removed after successful completion.");
+            message.push_str(
+                "\nContainer will be kept if the command fails or Docker reports OOMKilled.",
+            );
+            message.push_str(&format!(
+                "\nRemove when done: docker rm -f {}",
+                container_name
+            ));
+        }
         DockerContainerCleanupPolicy::Keep => {
             message.push('\n');
             message.push_str(&docker_container_cleanup_instructions(container_name));
         }
         DockerContainerCleanupPolicy::KeepOnFail => {
             message.push_str("\nContainer will be removed after successful completion.");
-            message.push_str("\nContainer will be kept if the command fails.");
+            message.push_str(
+                "\nContainer will be kept if the command fails or Docker reports OOMKilled.",
+            );
             message.push_str(&format!(
                 "\nRemove when done: docker rm -f {}",
                 container_name
             ));
         }
+    }
+}
+
+pub(crate) fn read_docker_container_oom_killed(container_name: &str) -> Option<bool> {
+    let output = Command::new("docker")
+        .args(["inspect", "-f", "{{.State.OOMKilled}}", container_name])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    match String::from_utf8_lossy(&output.stdout).trim() {
+        "true" => Some(true),
+        "false" => Some(false),
+        _ => None,
     }
 }
 
@@ -119,6 +155,18 @@ pub(crate) fn remove_docker_container(container_name: &str, log_path: Option<&Pa
     }
 }
 
+fn build_docker_kept_log_snippet(container_name: &str, quoted_log_path: &str) -> String {
+    let quoted_name = shell_quote(container_name);
+    format!(
+        "printf '\\nContainer kept for investigation: %s\\nReason: exitCode=%s oomKilled=%s\\nInspect: docker exec -it %s sh (if running) or docker start -ai %s\\nRemove when done: docker rm -f %s\\n' {} \"$__start_command_exit\" \"$__start_command_oom\" {} {} {} >> {}",
+        quoted_name, quoted_name, quoted_name, quoted_name, quoted_log_path
+    )
+}
+
+fn successful_non_oom_condition() -> &'static str {
+    "[ \"$__start_command_exit\" -eq 0 ] 2>/dev/null && [ \"$__start_command_oom\" != true ]"
+}
+
 fn build_detached_docker_completion_script(
     container_name: &str,
     policy: DockerContainerCleanupPolicy,
@@ -135,17 +183,29 @@ fn build_detached_docker_completion_script(
             quoted_name, quoted_log_path
         ));
         parts.push(format!(
-            "__start_command_exit=$(docker inspect -f '{{{{.State.ExitCode}}}}' {} 2>/dev/null || printf '%s' '-1')",
+            "__start_command_state=$(docker inspect -f '{{{{.State.ExitCode}}}} {{{{.State.OOMKilled}}}}' {} 2>/dev/null || printf '%s' '-1 false')",
             quoted_name
         ));
+        parts.push("__start_command_exit=${__start_command_state%% *}".to_string());
+        parts.push("__start_command_oom=${__start_command_state##* }".to_string());
         match policy {
             DockerContainerCleanupPolicy::Always => parts.push(format!(
                 "docker rm -f {} >> {} 2>&1 || true",
                 quoted_name, quoted_log_path
             )),
+            DockerContainerCleanupPolicy::Default => parts.push(format!(
+                "if {}; then docker rm -f {} >> {} 2>&1 || true; else {}; fi",
+                successful_non_oom_condition(),
+                quoted_name,
+                quoted_log_path,
+                build_docker_kept_log_snippet(container_name, &quoted_log_path)
+            )),
             DockerContainerCleanupPolicy::KeepOnFail => parts.push(format!(
-                "if [ \"$__start_command_exit\" -eq 0 ] 2>/dev/null; then docker rm -f {} >> {} 2>&1 || true; fi",
-                quoted_name, quoted_log_path
+                "if {}; then docker rm -f {} >> {} 2>&1 || true; else {}; fi",
+                successful_non_oom_condition(),
+                quoted_name,
+                quoted_log_path,
+                build_docker_kept_log_snippet(container_name, &quoted_log_path)
             )),
             DockerContainerCleanupPolicy::Keep => {}
         }
@@ -157,16 +217,24 @@ fn build_detached_docker_completion_script(
     } else {
         parts.push(format!("docker wait {} >/dev/null 2>&1", quoted_name));
         parts.push(format!(
-            "__start_command_exit=$(docker inspect -f '{{{{.State.ExitCode}}}}' {} 2>/dev/null || printf '%s' '-1')",
+            "__start_command_state=$(docker inspect -f '{{{{.State.ExitCode}}}} {{{{.State.OOMKilled}}}}' {} 2>/dev/null || printf '%s' '-1 false')",
             quoted_name
         ));
+        parts.push("__start_command_exit=${__start_command_state%% *}".to_string());
+        parts.push("__start_command_oom=${__start_command_state##* }".to_string());
         match policy {
             DockerContainerCleanupPolicy::Always => parts.push(format!(
                 "docker rm -f {} >/dev/null 2>&1 || true",
                 quoted_name
             )),
+            DockerContainerCleanupPolicy::Default => parts.push(format!(
+                "if {}; then docker rm -f {} >/dev/null 2>&1 || true; fi",
+                successful_non_oom_condition(),
+                quoted_name
+            )),
             DockerContainerCleanupPolicy::KeepOnFail => parts.push(format!(
-                "if [ \"$__start_command_exit\" -eq 0 ] 2>/dev/null; then docker rm -f {} >/dev/null 2>&1 || true; fi",
+                "if {}; then docker rm -f {} >/dev/null 2>&1 || true; fi",
+                successful_non_oom_condition(),
                 quoted_name
             )),
             DockerContainerCleanupPolicy::Keep => {}
@@ -287,4 +355,59 @@ pub(crate) fn spawn_attached_docker(
         stdout_thread,
         stderr_thread,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_policy_keeps_abnormal_containers() {
+        let options = IsolationOptions::default();
+        let policy = get_docker_container_cleanup_policy(&options);
+        assert_eq!(policy, DockerContainerCleanupPolicy::Default);
+        assert!(should_cleanup_docker_container(policy, 0, false));
+        assert!(!should_cleanup_docker_container(policy, 7, false));
+        assert!(!should_cleanup_docker_container(policy, 0, true));
+    }
+
+    #[test]
+    fn keep_on_fail_policy_keeps_oom_killed_containers() {
+        let options = IsolationOptions {
+            keep_container_on_fail: true,
+            ..IsolationOptions::default()
+        };
+        let policy = get_docker_container_cleanup_policy(&options);
+        assert_eq!(policy, DockerContainerCleanupPolicy::KeepOnFail);
+        assert!(should_cleanup_docker_container(policy, 0, false));
+        assert!(!should_cleanup_docker_container(policy, 0, true));
+    }
+
+    #[test]
+    fn explicit_always_policy_cleans_abnormal_containers() {
+        let options = IsolationOptions {
+            always_cleanup_container: true,
+            ..IsolationOptions::default()
+        };
+        let policy = get_docker_container_cleanup_policy(&options);
+        assert_eq!(policy, DockerContainerCleanupPolicy::Always);
+        assert!(should_cleanup_docker_container(policy, 7, false));
+        assert!(should_cleanup_docker_container(policy, 0, true));
+    }
+
+    #[test]
+    fn detached_watcher_inspects_oom_killed_before_default_cleanup() {
+        let log_path = PathBuf::from("/tmp/issue144.log");
+        let script = build_detached_docker_completion_script(
+            "issue144-container",
+            DockerContainerCleanupPolicy::Default,
+            Some(&log_path),
+        );
+        assert!(script.contains(".State.ExitCode"));
+        assert!(script.contains(".State.OOMKilled"));
+        assert!(script.contains("__start_command_oom"));
+        assert!(script.contains("Container kept for investigation"));
+        assert!(script.contains("docker rm -f"));
+        assert!(script.contains("issue144-container"));
+    }
 }

--- a/rust/src/lib/execution_control.rs
+++ b/rust/src/lib/execution_control.rs
@@ -4,6 +4,7 @@
 //! controls so callers can stop or terminate a running session by UUID or
 //! session name.
 
+use crate::docker_cleanup::docker_command;
 use crate::execution_store::{ExecutionRecord, ExecutionStore};
 use crate::output_blocks::{escape_for_links_notation, format_value_for_links_notation};
 use serde_json::{json, Map, Value};
@@ -235,7 +236,8 @@ pub fn collect_process_ids_with_runner<R: CommandRunner>(
                 "{{.Id}} {{.State.Pid}}".to_string(),
                 session_name.to_string(),
             ];
-            let result = runner.run("docker", &inspect_args);
+            let docker = docker_command().to_string_lossy().to_string();
+            let result = runner.run(&docker, &inspect_args);
             if result.success && !result.stdout.trim().is_empty() {
                 let mut parts = result.stdout.split_whitespace();
                 if let Some(container_id) = parts.next() {

--- a/rust/src/lib/execution_store.rs
+++ b/rust/src/lib/execution_store.rs
@@ -64,6 +64,8 @@ pub struct ExecutionRecord {
     pub log_path: String,
     pub start_time: String,
     pub end_time: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub oom_killed: Option<bool>,
     pub working_directory: String,
     pub shell: String,
     pub platform: String,
@@ -84,6 +86,7 @@ impl ExecutionRecord {
             log_path: String::new(),
             start_time: now.to_rfc3339(),
             end_time: None,
+            oom_killed: None,
             working_directory: env::current_dir()
                 .map(|p| p.to_string_lossy().to_string())
                 .unwrap_or_default(),
@@ -116,6 +119,9 @@ impl ExecutionRecord {
         }
         if let Some(end_time) = options.end_time {
             record.end_time = Some(end_time);
+        }
+        if let Some(oom_killed) = options.oom_killed {
+            record.oom_killed = Some(oom_killed);
         }
         if let Some(working_directory) = options.working_directory {
             record.working_directory = working_directory;
@@ -161,6 +167,7 @@ pub struct ExecutionRecordOptions {
     pub log_path: Option<String>,
     pub start_time: Option<String>,
     pub end_time: Option<String>,
+    pub oom_killed: Option<bool>,
     pub working_directory: Option<String>,
     pub shell: Option<String>,
     pub platform: Option<String>,

--- a/rust/src/lib/isolation.rs
+++ b/rust/src/lib/isolation.rs
@@ -14,8 +14,8 @@ use crate::args_parser::generate_session_name;
 use crate::docker_cleanup::{
     append_docker_container_cleanup_policy_message, build_docker_runtime_args,
     docker_container_cleanup_instructions, get_docker_container_cleanup_policy,
-    remove_docker_container, should_cleanup_docker_container, spawn_attached_docker,
-    start_detached_docker_completion_watcher, DockerContainerCleanupPolicy,
+    read_docker_container_oom_killed, remove_docker_container, should_cleanup_docker_container,
+    spawn_attached_docker, start_detached_docker_completion_watcher, DockerContainerCleanupPolicy,
 };
 
 /// Result of an isolation run
@@ -60,11 +60,11 @@ pub struct IsolationOptions {
     pub keep_alive: bool,
     /// Auto-remove docker container after exit
     pub auto_remove_docker_container: bool,
-    /// Explicitly request default always-cleanup docker policy
+    /// Force docker container cleanup after exit
     pub always_cleanup_container: bool,
     /// Keep docker container filesystem after exit
     pub keep_container: bool,
-    /// Keep docker container filesystem only when command fails
+    /// Keep docker container filesystem when command fails or OOM-kills
     pub keep_container_on_fail: bool,
     /// Shell to use in isolation environments: auto, bash, zsh, sh
     pub shell: String,
@@ -873,7 +873,9 @@ pub fn run_in_docker(command: &str, options: &IsolationOptions) -> IsolationResu
                         "Docker container \"{}\" exited with code {}",
                         container_name, exit_code
                     );
-                    if should_cleanup_docker_container(cleanup_policy, exit_code) {
+                    let oom_killed =
+                        read_docker_container_oom_killed(&container_name).unwrap_or(false);
+                    if should_cleanup_docker_container(cleanup_policy, exit_code, oom_killed) {
                         if remove_docker_container(&container_name, options.log_path.as_ref()) {
                             message.push_str("\nContainer removed after completion.");
                         } else {
@@ -887,8 +889,18 @@ pub fn run_in_docker(command: &str, options: &IsolationOptions) -> IsolationResu
                     } else if cleanup_policy == DockerContainerCleanupPolicy::Keep {
                         message.push('\n');
                         message.push_str(&docker_container_cleanup_instructions(&container_name));
-                    } else if cleanup_policy == DockerContainerCleanupPolicy::KeepOnFail {
-                        message.push_str("\nContainer kept because the command failed.");
+                    } else if matches!(
+                        cleanup_policy,
+                        DockerContainerCleanupPolicy::KeepOnFail
+                            | DockerContainerCleanupPolicy::Default
+                    ) {
+                        if oom_killed {
+                            message.push_str(
+                                "\nContainer kept because Docker reports it was OOM-killed.",
+                            );
+                        } else {
+                            message.push_str("\nContainer kept because the command failed.");
+                        }
                         message.push_str(&format!(
                             "\nRemove when done: docker rm -f {}",
                             container_name

--- a/rust/src/lib/status_formatter.rs
+++ b/rust/src/lib/status_formatter.rs
@@ -5,6 +5,7 @@
 //! - JSON: Standard JSON output
 //! - Text: Human-readable text format
 
+use crate::docker_cleanup::docker_command;
 use crate::execution_control::collect_process_ids;
 use crate::execution_store::{ExecutionRecord, ExecutionStatus, ExecutionStore};
 use crate::output_blocks::{escape_for_links_notation, format_value_for_links_notation};
@@ -31,7 +32,7 @@ struct DockerState {
 /// Returns None when the container cannot be inspected (not found yet, removed,
 /// or docker error).
 fn inspect_docker_state(session_name: &str) -> Option<DockerState> {
-    let output = Command::new("docker")
+    let output = Command::new(docker_command())
         .args([
             "inspect",
             "-f",
@@ -773,7 +774,8 @@ mod tests {
     use crate::execution_store::{ExecutionRecordOptions, ExecutionStoreOptions};
     use serde_json::json;
     use std::collections::HashMap;
-    use std::path::Path;
+    use std::panic::{catch_unwind, resume_unwind, AssertUnwindSafe};
+    use std::path::{Path, PathBuf};
     use tempfile::TempDir;
 
     fn executing_record() -> ExecutionRecord {
@@ -812,7 +814,7 @@ mod tests {
         })
     }
 
-    fn write_fake_docker(fake_dir: &Path, state_line: &str) {
+    fn write_fake_docker(fake_dir: &Path, state_line: &str) -> PathBuf {
         #[cfg(windows)]
         {
             let script = [
@@ -828,7 +830,9 @@ mod tests {
                 "",
             ]
             .join("\r\n");
-            std::fs::write(fake_dir.join("docker.cmd"), script).unwrap();
+            let docker_path = fake_dir.join("docker.cmd");
+            std::fs::write(&docker_path, script).unwrap();
+            docker_path
         }
 
         #[cfg(not(windows))]
@@ -850,24 +854,35 @@ mod tests {
             let mut permissions = std::fs::metadata(&docker_path).unwrap().permissions();
             permissions.set_mode(0o755);
             std::fs::set_permissions(&docker_path, permissions).unwrap();
+            docker_path
         }
     }
 
     fn with_fake_docker_inspect<F: FnOnce()>(state_line: &str, run: F) {
         let fake_dir = TempDir::new().unwrap();
-        write_fake_docker(fake_dir.path(), state_line);
+        let docker_path = write_fake_docker(fake_dir.path(), state_line);
         let original_path = std::env::var_os("PATH");
+        let original_docker_bin = std::env::var_os("START_DOCKER_BIN");
         let mut paths = vec![fake_dir.path().to_path_buf()];
         if let Some(existing) = original_path.as_ref() {
             paths.extend(std::env::split_paths(existing));
         }
         let joined = std::env::join_paths(paths).unwrap();
         std::env::set_var("PATH", &joined);
-        run();
+        std::env::set_var("START_DOCKER_BIN", &docker_path);
+        let result = catch_unwind(AssertUnwindSafe(run));
         if let Some(path) = original_path {
             std::env::set_var("PATH", path);
         } else {
             std::env::remove_var("PATH");
+        }
+        if let Some(path) = original_docker_bin {
+            std::env::set_var("START_DOCKER_BIN", path);
+        } else {
+            std::env::remove_var("START_DOCKER_BIN");
+        }
+        if let Err(payload) = result {
+            resume_unwind(payload);
         }
     }
 

--- a/rust/src/lib/status_formatter.rs
+++ b/rust/src/lib/status_formatter.rs
@@ -16,6 +16,7 @@ use std::process::Command;
 struct DockerState {
     running: bool,
     exit_code: Option<i32>,
+    oom_killed: Option<bool>,
 }
 
 /// Inspect the live state of a detached docker container by name.
@@ -34,7 +35,7 @@ fn inspect_docker_state(session_name: &str) -> Option<DockerState> {
         .args([
             "inspect",
             "-f",
-            "{{.State.Running}} {{.State.ExitCode}}",
+            "{{.State.Running}} {{.State.ExitCode}} {{.State.OOMKilled}}",
             session_name,
         ])
         .output()
@@ -50,7 +51,16 @@ fn inspect_docker_state(session_name: &str) -> Option<DockerState> {
     let mut parts = trimmed.split_whitespace();
     let running = parts.next() == Some("true");
     let exit_code = parts.next().and_then(|value| value.parse::<i32>().ok());
-    Some(DockerState { running, exit_code })
+    let oom_killed = parts.next().and_then(|value| match value {
+        "true" => Some(true),
+        "false" => Some(false),
+        _ => None,
+    });
+    Some(DockerState {
+        running,
+        exit_code,
+        oom_killed,
+    })
 }
 
 /// Best-effort terminal exit code reported by the isolation backend itself
@@ -68,6 +78,14 @@ fn read_backend_exit_code(record: &ExecutionRecord) -> Option<i32> {
     } else {
         state.exit_code
     }
+}
+
+fn read_docker_oom_killed(record: &ExecutionRecord) -> Option<bool> {
+    if record.options.get("isolated")?.as_str()? != "docker" {
+        return None;
+    }
+    let session_name = record.options.get("sessionName")?.as_str()?;
+    inspect_docker_state(session_name)?.oom_killed
 }
 
 /// Check if a detached isolation session is still running
@@ -164,6 +182,9 @@ pub fn enrich_detached_status(record: &ExecutionRecord) -> ExecutionRecord {
     };
 
     let mut enriched = record.clone();
+    if let Some(oom_killed) = read_docker_oom_killed(&enriched) {
+        enriched.oom_killed = Some(oom_killed);
+    }
 
     if alive && enriched.status == ExecutionStatus::Executed {
         // A live `screen -ls` (or `tmux`/`docker`) session does NOT mean the command
@@ -407,8 +428,11 @@ fn format_record_as_text_with_enrichments(
         format!("Status:            {}", record.status),
         format!("Command:           {}", record.command),
         format!("Exit Code:         {}", exit_code_str),
-        format!("PID:               {}", pid_str),
     ];
+    if let Some(oom_killed) = record.oom_killed {
+        lines.push(format!("OOM Killed:        {}", oom_killed));
+    }
+    lines.push(format!("PID:               {}", pid_str));
     if let Some(process_ids) = process_ids {
         append_text_process_ids(&mut lines, process_ids);
     }
@@ -746,8 +770,11 @@ pub fn query_status(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::execution_store::ExecutionRecordOptions;
+    use crate::execution_store::{ExecutionRecordOptions, ExecutionStoreOptions};
     use serde_json::json;
+    use std::collections::HashMap;
+    use std::path::Path;
+    use tempfile::TempDir;
 
     fn executing_record() -> ExecutionRecord {
         ExecutionRecord::with_options(ExecutionRecordOptions {
@@ -762,6 +789,86 @@ mod tests {
             platform: Some("linux".to_string()),
             ..Default::default()
         })
+    }
+
+    fn docker_record() -> ExecutionRecord {
+        let mut options = HashMap::new();
+        options.insert(
+            "sessionName".to_string(),
+            Value::String("issue144-oom".to_string()),
+        );
+        options.insert("isolated".to_string(), Value::String("docker".to_string()));
+        options.insert(
+            "isolationMode".to_string(),
+            Value::String("detached".to_string()),
+        );
+
+        ExecutionRecord::with_options(ExecutionRecordOptions {
+            command: "sh -c 'exit 0'".to_string(),
+            uuid: Some("issue144-rust".to_string()),
+            log_path: Some("/tmp/issue144.log".to_string()),
+            options: Some(options),
+            ..Default::default()
+        })
+    }
+
+    fn write_fake_docker(fake_dir: &Path, state_line: &str) {
+        #[cfg(windows)]
+        {
+            let script = [
+                "@echo off",
+                "if not \"%1\"==\"inspect\" exit /b 1",
+                "echo %3 | findstr /C:\"State.Pid\" >nul",
+                "if %errorlevel%==0 (",
+                "  echo fake-container-id 4321",
+                "  exit /b 0",
+                ")",
+                &format!("echo {}", state_line),
+                "exit /b 0",
+                "",
+            ]
+            .join("\r\n");
+            std::fs::write(fake_dir.join("docker.cmd"), script).unwrap();
+        }
+
+        #[cfg(not(windows))]
+        {
+            use std::os::unix::fs::PermissionsExt;
+
+            let script = [
+                "#!/bin/sh",
+                "[ \"$1\" = \"inspect\" ] || exit 1",
+                "case \"$3\" in",
+                "  *State.Pid*) echo \"fake-container-id 4321\" ;;",
+                &format!("  *) echo \"{}\" ;;", state_line),
+                "esac",
+                "",
+            ]
+            .join("\n");
+            let docker_path = fake_dir.join("docker");
+            std::fs::write(&docker_path, script).unwrap();
+            let mut permissions = std::fs::metadata(&docker_path).unwrap().permissions();
+            permissions.set_mode(0o755);
+            std::fs::set_permissions(&docker_path, permissions).unwrap();
+        }
+    }
+
+    fn with_fake_docker_inspect<F: FnOnce()>(state_line: &str, run: F) {
+        let fake_dir = TempDir::new().unwrap();
+        write_fake_docker(fake_dir.path(), state_line);
+        let original_path = std::env::var_os("PATH");
+        let mut paths = vec![fake_dir.path().to_path_buf()];
+        if let Some(existing) = original_path.as_ref() {
+            paths.extend(std::env::split_paths(existing));
+        }
+        let joined = std::env::join_paths(paths).unwrap();
+        std::env::set_var("PATH", &joined);
+        run();
+        if let Some(path) = original_path {
+            std::env::set_var("PATH", path);
+        } else {
+            std::env::remove_var("PATH");
+        }
     }
 
     #[test]
@@ -791,5 +898,45 @@ mod tests {
             "opening parenthesis must not start at column 1: {}",
             output
         );
+    }
+
+    #[test]
+    fn docker_oom_killed_is_exposed_in_status_and_list_output() {
+        let temp_dir = TempDir::new().unwrap();
+        let store = ExecutionStore::with_options(ExecutionStoreOptions {
+            app_folder: Some(temp_dir.path().to_path_buf()),
+            use_links: Some(false),
+            verbose: false,
+        });
+        let record = docker_record();
+        store.save(&record).unwrap();
+
+        with_fake_docker_inspect("false 0 true", || {
+            let json_result = query_status(Some(&store), "issue144-rust", Some("json"));
+            assert!(json_result.success);
+            let parsed: Value = serde_json::from_str(&json_result.output.unwrap()).unwrap();
+            assert_eq!(parsed["status"], "executed");
+            assert_eq!(parsed["exitCode"], 0);
+            assert_eq!(parsed["oomKilled"], true);
+
+            let links_result = query_status(Some(&store), "issue144-rust", Some("links-notation"));
+            assert!(links_result.success);
+            assert!(links_result.output.unwrap().contains("  oomKilled true"));
+
+            let text_result = query_status(Some(&store), "issue144-rust", Some("text"));
+            assert!(text_result.success);
+            assert!(text_result
+                .output
+                .unwrap()
+                .contains("OOM Killed:        true"));
+
+            let list_result = list_executions(Some(&store), Some("json"));
+            assert!(list_result.success);
+            let listed: Value = serde_json::from_str(&list_result.output.unwrap()).unwrap();
+            assert_eq!(listed["count"], 1);
+            assert_eq!(listed["executions"][0]["status"], "executed");
+            assert_eq!(listed["executions"][0]["exitCode"], 0);
+            assert_eq!(listed["executions"][0]["oomKilled"], true);
+        });
     }
 }

--- a/rust/src/lib/usage.rs
+++ b/rust/src/lib/usage.rs
@@ -26,9 +26,9 @@ Options:
   --keep-user           Keep isolated user after command completes
   --keep-alive, -k      Keep isolation environment alive after command exits
   --auto-remove-docker-container  Always remove docker container after exit (compatibility alias)
-  --always-cleanup-container  Always remove docker container after exit (default)
+  --always-cleanup-container  Always remove docker container after exit
   --keep-container     Keep docker container filesystem after exit
-  --keep-container-on-fail  Remove successful docker containers, keep failed ones
+  --keep-container-on-fail  Remove successful docker containers, keep failed or OOM-killed ones
   --shell <shell>       Shell to use in isolation environments: auto, bash, zsh, sh (default: auto)
   --use-command-stream  Use command-stream library for execution (experimental)
   --status <id>         Show status of execution by UUID or session name (--output-format: links-notation|json|text)


### PR DESCRIPTION
Fixes #144.

## Summary
- Expose Docker `State.OOMKilled` as `oomKilled` in detached `--status` and `--list` output for text, JSON, and links notation.
- Change the default Docker cleanup policy to remove successful, non-OOM containers while preserving containers that fail or report `OOMKilled`.
- Add post-run detached log hints for preserved abnormal containers, plus attached-mode cleanup hints.
- Keep explicit cleanup flags available: `--always-cleanup-container` / `--auto-remove-docker-container` force removal, `--keep-container` preserves every run, and `--keep-container-on-fail` also treats OOMKilled as abnormal.
- Add JS changeset and Rust changelog fragment for patch releases.

## Reproduction / Verification
- Added JS and Rust status/list tests that save a detached Docker record and fake `docker inspect` as `false 0 true`, verifying `status: executed`, `exitCode: 0`, and `oomKilled: true` in structured output.
- Added JS and Rust cleanup decision tests showing the default policy keeps nonzero and OOMKilled containers, while explicit always cleanup still removes them.
- Added detached watcher script tests verifying it inspects `.State.OOMKilled` before default cleanup.

## Tests
- `cd js && bun test ./test/session-name-status.js ./test/docker-autoremove.js`
- `cargo test --manifest-path rust/Cargo.toml docker_cleanup::tests`
- `cargo test --manifest-path rust/Cargo.toml docker_oom_killed_is_exposed_in_status_and_list_output`
- `cd js && bun run check`
- `bash scripts/check-mjs-syntax.sh`
- `cargo fmt --manifest-path rust/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path rust/Cargo.toml --all-targets --all-features`
- `cd js && bun run test`
- `cargo test --manifest-path rust/Cargo.toml --all-features --verbose`
- `cargo test --manifest-path rust/Cargo.toml --doc --verbose`
- `node scripts/check-test-parity.mjs`
- `node scripts/validate-changeset.mjs`

Screenshots are not applicable; this is CLI/runtime behavior.
