### PR TITLE
feat: support multiple Docker networks

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-08-10T10:17:47.154Z for PR creation at branch issue-156-a9778f176d79 for issue https://github.com/link-foundation/start/issues/156

--- a/README.md
+++ b/README.md
@@ -318,8 +318,8 @@ This is useful for:
 | `--mount`                        | Docker `--mount` spec (repeatable, docker only)                              |
 | `--env, -e`                      | Environment variable `KEY=VALUE` for the container (repeatable, docker only) |
 | `--privileged`                   | Run docker container in privileged mode (docker only)                        |
-| `--network`                      | Connect docker container to a named network (docker only)                    |
-| `--network-alias`                | Add a network-scoped alias (repeatable, docker only)                         |
+| `--network`                      | Connect to a named network (repeatable, docker only)                         |
+| `--network-alias`                | Add an alias on the first network (repeatable, docker only)                  |
 | `--endpoint`                     | SSH endpoint (required for ssh, e.g., user@host)                             |
 | `--isolated-user, -u [name]`     | Create isolated user with same permissions (screen/tmux)                     |
 | `--keep-user`                    | Keep isolated user after command completes (don't delete)                    |
@@ -330,6 +330,17 @@ This is useful for:
 | `--keep-container-on-fail`       | Keep failed or OOM-killed docker containers after exit (docker only)         |
 
 **Note:** Using both `--attached` and `--detached` together will result in an error - you must choose one mode.
+
+When `--network` is repeated, Docker creates the container on the first network,
+connects every additional network, and only then starts the command. This lets a
+container retain egress through one network while reaching services on a private
+network without a startup race. Repeated `--network-alias` values apply to the
+first network.
+
+```bash
+$ --isolated docker --image alpine:3.23 \
+    --network bridge --network my-sidecar-net -- ping -c 1 sidecar
+```
 
 #### Auto-Exit Behavior
 

--- a/js/.changeset/issue-156-repeatable-networks.md
+++ b/js/.changeset/issue-156-repeatable-networks.md
@@ -1,0 +1,5 @@
+---
+'start-command': minor
+---
+
+Allow Docker isolation to join multiple networks before starting the command.

--- a/js/src/lib/args-parser.js
+++ b/js/src/lib/args-parser.js
@@ -4,7 +4,6 @@
  * Supports two syntax patterns:
  * 1. $ [wrapper-options] -- [command-options]
  * 2. $ [wrapper-options] command [command-options]
- *
  * Wrapper Options:
  * --isolated, --isolation, -i <backend> Run in isolated environment (screen, tmux, docker, ssh)
  * --attached, -a                   Run in attached mode (foreground)
@@ -15,8 +14,8 @@
  * --mount <mount-spec>             Docker --mount spec (repeatable, docker only)
  * --env, -e <KEY=VALUE>            Environment variable for docker container (repeatable, docker only)
  * --privileged                     Run docker container in privileged mode (docker only)
- * --network <name>                 Connect docker container to a named network (docker only)
- * --network-alias <alias>          Add a network-scoped alias (repeatable, docker only)
+ * --network <name>                 Connect docker container to a named network (repeatable, docker only)
+ * --network-alias <alias>          Add an alias to the first network (repeatable, docker only)
  * --endpoint <endpoint>            SSH endpoint (required for ssh isolation, e.g., user@host)
  * --isolated-user, -u [username]   Create isolated user with same permissions (auto-generated name if not specified)
  * --keep-user                      Keep isolated user after command completes (don't delete)
@@ -181,7 +180,8 @@ function parseArgs(args) {
     mounts: [], // Docker --mount specs, applied to docker levels
     env: [], // Docker environment variables (-e/--env, KEY=VALUE), applied to docker levels
     privileged: false, // Run docker container in privileged mode
-    network: null, // Docker network name
+    network: null, // First Docker network name (compatibility accessor)
+    networks: [], // Ordered Docker network names
     networkAliases: [], // Docker network-scoped aliases
     endpoint: null, // SSH endpoint (current level, e.g., user@host)
     endpointStack: null, // SSH endpoints for each level (with nulls for non-ssh levels)

--- a/js/src/lib/docker-network-lifecycle.js
+++ b/js/src/lib/docker-network-lifecycle.js
@@ -1,0 +1,41 @@
+/** Docker multi-network lifecycle helpers. */
+
+const { spawnSync } = require('child_process');
+
+function getDockerNetworks(options = {}) {
+  return options.networks?.length
+    ? options.networks
+    : options.network
+      ? [options.network]
+      : [];
+}
+
+function runDockerCommand(args) {
+  const result = spawnSync('docker', args, {
+    encoding: 'utf8',
+    stdio: ['pipe', 'pipe', 'pipe'],
+  });
+  if (result.error) {
+    throw result.error;
+  }
+  if (result.status !== 0) {
+    throw new Error(
+      result.stderr.trim() ||
+        result.stdout.trim() ||
+        `docker ${args[0]} exited with code ${result.status}`
+    );
+  }
+  return result.stdout.trim();
+}
+
+function connectAdditionalDockerNetworks(containerName, options = {}) {
+  for (const network of getDockerNetworks(options).slice(1)) {
+    runDockerCommand(['network', 'connect', network, containerName]);
+  }
+}
+
+module.exports = {
+  connectAdditionalDockerNetworks,
+  getDockerNetworks,
+  runDockerCommand,
+};

--- a/js/src/lib/docker-network-options.js
+++ b/js/src/lib/docker-network-options.js
@@ -8,14 +8,17 @@ function parseDockerNetworkOption(args, index, options) {
       throw new Error(`Option ${arg} requires a ${value} argument`);
     }
     if (arg === '--network') {
-      options.network = args[index + 1];
+      options.networks.push(args[index + 1]);
+      options.network ??= args[index + 1];
     } else {
       options.networkAliases.push(args[index + 1]);
     }
     return 2;
   }
   if (arg.startsWith('--network=')) {
-    options.network = arg.slice('--network='.length);
+    const network = arg.slice('--network='.length);
+    options.networks.push(network);
+    options.network ??= network;
     return 1;
   }
   if (arg.startsWith('--network-alias=')) {

--- a/js/src/lib/isolation.js
+++ b/js/src/lib/isolation.js
@@ -4,6 +4,11 @@ const { execSync, spawn, spawnSync } = require('child_process');
 const path = require('path');
 const { generateSessionName } = require('./args-parser');
 const outputBlocks = require('./output-blocks');
+const {
+  connectAdditionalDockerNetworks,
+  getDockerNetworks,
+  runDockerCommand,
+} = require('./docker-network-lifecycle');
 
 // Debug mode from environment
 const DEBUG =
@@ -519,8 +524,9 @@ function buildDockerRuntimeArgs(options = {}) {
   for (const mount of options.mounts || []) {
     args.push('--mount', mount);
   }
-  if (options.network) {
-    args.push('--network', options.network);
+  const [firstNetwork] = getDockerNetworks(options);
+  if (firstNetwork) {
+    args.push('--network', firstNetwork);
   }
   for (const alias of options.networkAliases || []) {
     args.push('--network-alias', alias);
@@ -532,7 +538,7 @@ function buildDockerRuntimeArgs(options = {}) {
  * Build the human-readable `[Isolation]` status lines for docker runtime
  * options (volumes, mounts, env, privileged). Empty collections and a falsy
  * privileged flag contribute no lines.
- * @param {object} options - Options (volumes, mounts, env, privileged)
+ * @param {object} options - Options (volumes, mounts, env, privileged, network, networks, networkAliases)
  * @returns {string[]} Status lines for the start block / log header
  */
 function buildDockerRuntimeStatusLines(options = {}) {
@@ -549,8 +555,12 @@ function buildDockerRuntimeStatusLines(options = {}) {
   if (options.privileged) {
     lines.push(`[Isolation] Privileged: true`);
   }
-  if (options.network) {
-    lines.push(`[Isolation] Network: ${options.network}`);
+  const networks = getDockerNetworks(options);
+  if (networks.length > 0) {
+    lines.push(`[Isolation] Network: ${networks[0]}`);
+  }
+  if (networks.length > 1) {
+    lines.push(`[Isolation] Networks: ${networks.join(', ')}`);
   }
   if (options.networkAliases && options.networkAliases.length > 0) {
     lines.push(
@@ -563,17 +573,19 @@ function buildDockerRuntimeStatusLines(options = {}) {
 /**
  * Build the execution-record metadata for docker runtime options, normalizing
  * empty collections and a falsy privileged flag to `null`.
- * @param {object} options - Options (volumes, mounts, env, privileged)
- * @returns {{volumes: ?string[], mounts: ?string[], env: ?string[], privileged: ?boolean, network: ?string, networkAliases: ?string[]}}
+ * @param {object} options - Options (volumes, mounts, env, privileged, network, networks, networkAliases)
+ * @returns {{volumes: ?string[], mounts: ?string[], env: ?string[], privileged: ?boolean, network: ?string, networks: ?string[], networkAliases: ?string[]}}
  */
 function buildDockerRuntimeMetadata(options = {}) {
+  const networks = getDockerNetworks(options);
   return {
     volumes:
       options.volumes && options.volumes.length > 0 ? options.volumes : null,
     mounts: options.mounts && options.mounts.length > 0 ? options.mounts : null,
     env: options.env && options.env.length > 0 ? options.env : null,
     privileged: options.privileged || null,
-    network: options.network || null,
+    network: networks[0] || null,
+    networks: networks.length > 0 ? networks : null,
     networkAliases:
       options.networkAliases && options.networkAliases.length > 0
         ? options.networkAliases
@@ -644,8 +656,9 @@ function runInDocker(command, options = {}) {
   console.log();
 
   try {
+    const needsNetworkSetup = getDockerNetworks(options).length > 1;
     if (options.detached) {
-      const dockerArgs = ['run', '-d'];
+      const dockerArgs = needsNetworkSetup ? ['create'] : ['run', '-d'];
       if (options.keepAlive) {
         dockerArgs.push('-i', '-t');
       }
@@ -704,6 +717,18 @@ function runInDocker(command, options = {}) {
 
       const containerId = dockerResult.stdout.trim();
 
+      if (needsNetworkSetup) {
+        try {
+          connectAdditionalDockerNetworks(containerName, options);
+          runDockerCommand(['start', containerName]);
+        } catch (error) {
+          if (!containerExistedBeforeLaunch) {
+            removeDockerContainer(containerName, options.logPath);
+          }
+          throw error;
+        }
+      }
+
       startDetachedDockerCompletionWatcher(
         containerName,
         cleanupPolicy,
@@ -735,7 +760,7 @@ function runInDocker(command, options = {}) {
         message,
       });
     } else {
-      const dockerArgs = ['run'];
+      const dockerArgs = [needsNetworkSetup ? 'create' : 'run'];
       dockerArgs.push(hasTTY() ? '-it' : '-i');
       dockerArgs.push('--name', containerName);
       if (options.user) {
@@ -769,9 +794,24 @@ function runInDocker(command, options = {}) {
         console.log(`[DEBUG] Running: docker ${dockerArgs.join(' ')}`);
       }
 
+      if (needsNetworkSetup) {
+        try {
+          runDockerCommand(dockerArgs);
+          connectAdditionalDockerNetworks(containerName, options);
+        } catch (error) {
+          if (!containerExistedBeforeLaunch) {
+            removeDockerContainer(containerName, options.logPath);
+          }
+          throw error;
+        }
+      }
+
       return new Promise((resolve) => {
         const startTime = Date.now();
-        const child = spawnAttachedDocker(dockerArgs, options.logPath);
+        const launchArgs = needsNetworkSetup
+          ? ['start', '-a', '-i', containerName]
+          : dockerArgs;
+        const child = spawnAttachedDocker(launchArgs, options.logPath);
 
         child.on('exit', (code) => {
           const durationMs = Date.now() - startTime;

--- a/js/src/lib/usage.js
+++ b/js/src/lib/usage.js
@@ -14,8 +14,8 @@ Options:
   --mount <spec>        Docker --mount spec (repeatable, docker only)
   --env, -e <KEY=VALUE> Environment variable for docker container (repeatable, docker only)
   --privileged          Run docker container in privileged mode (docker only)
-  --network <name>      Connect docker container to a named network (docker only)
-  --network-alias <alias> Add network-scoped alias (repeatable, docker only)
+  --network <name>      Connect to a named network (repeatable, docker only)
+  --network-alias <alias> Add alias to the first network (repeatable, docker only)
   --endpoint <endpoint> SSH endpoint (required for ssh isolation, e.g., user@host)
   --isolated-user, -u [name]  Create isolated user with same permissions
   --keep-user           Keep isolated user after command completes

--- a/js/test/docker-network-integration.js
+++ b/js/test/docker-network-integration.js
@@ -1,5 +1,5 @@
 #!/usr/bin/env bun
-/** Real-daemon integration coverage for Docker network isolation (issue #154). */
+/** Real-daemon integration coverage for Docker network isolation (issues #154, #156). */
 
 const { after, before, describe, it } = require('node:test');
 const assert = require('assert');
@@ -54,20 +54,23 @@ describe('Docker named network integration', { timeout: 60000 }, () => {
     docker(['network', 'rm', network]);
   });
 
-  it('resolves an alias only from containers joined to the internal network', async () => {
+  it('reaches a private sidecar and the internet through two networks', async () => {
     if (!dockerAvailable) {
       return;
     }
 
-    const joined = await runInDocker('ping -c 1 formal-ai', {
-      image: 'alpine:3.23',
-      session: connected,
-      network,
-      networkAliases: ['task'],
-      detached: true,
-      shell: 'sh',
-      keepContainer: true,
-    });
+    const joined = await runInDocker(
+      'ping -c 1 formal-ai && wget -q --spider https://api.github.com',
+      {
+        image: 'alpine:3.23',
+        session: connected,
+        network: 'bridge',
+        networks: ['bridge', network],
+        detached: true,
+        shell: 'sh',
+        keepContainer: true,
+      }
+    );
     assert.strictEqual(joined.success, true, joined.message);
     const joinedExit = docker(['wait', connected]);
     assert.strictEqual(joinedExit.status, 0, joinedExit.stderr);
@@ -96,6 +99,18 @@ describe('Docker named network integration', { timeout: 60000 }, () => {
     });
     assert.strictEqual(result.success, false);
     assert.match(result.message, /network .* not found/i);
+    assert.notStrictEqual(docker(['inspect', missing]).status, 0);
+
+    const missingSecond = await runInDocker('echo should-not-run', {
+      image: 'alpine:3.23',
+      session: missing,
+      network: 'bridge',
+      networks: ['bridge', `${network}-absent`],
+      detached: true,
+      shell: 'sh',
+    });
+    assert.strictEqual(missingSecond.success, false);
+    assert.match(missingSecond.message, /network .* not found/i);
     assert.notStrictEqual(docker(['inspect', missing]).status, 0);
 
     const attachedResult = await runInDocker('echo should-not-run', {

--- a/js/test/docker-runtime-options.js
+++ b/js/test/docker-runtime-options.js
@@ -91,12 +91,13 @@ describe('Docker runtime options parsing', () => {
     assert.strictEqual(result.wrapperOptions.privileged, true);
   });
 
-  it('should parse --network value and equals forms without consuming child args', () => {
+  it('should parse repeatable --network forms without consuming child args', () => {
     const spaced = parseArgs([
       '-i',
       'docker',
       '--network',
       'hive-formal-ai',
+      '--network=public-egress',
       '--',
       '--network',
       'child-network',
@@ -111,8 +112,13 @@ describe('Docker runtime options parsing', () => {
     ]);
 
     assert.strictEqual(spaced.wrapperOptions.network, 'hive-formal-ai');
+    assert.deepStrictEqual(spaced.wrapperOptions.networks, [
+      'hive-formal-ai',
+      'public-egress',
+    ]);
     assert.deepStrictEqual(spaced.rawCommand, ['--network', 'child-network']);
     assert.strictEqual(equals.wrapperOptions.network, 'hive-formal-ai');
+    assert.deepStrictEqual(equals.wrapperOptions.networks, ['hive-formal-ai']);
   });
 
   it('should parse repeatable --network-alias value and equals forms', () => {
@@ -142,6 +148,7 @@ describe('Docker runtime options parsing', () => {
     assert.deepStrictEqual(result.wrapperOptions.env, []);
     assert.strictEqual(result.wrapperOptions.privileged, false);
     assert.strictEqual(result.wrapperOptions.network, null);
+    assert.deepStrictEqual(result.wrapperOptions.networks, []);
     assert.deepStrictEqual(result.wrapperOptions.networkAliases, []);
   });
 
@@ -228,6 +235,7 @@ describe('buildDockerRuntimeArgs', () => {
       volumes: ['/h/a:/c/a', '/h/b:/c/b:ro'],
       mounts: ['type=bind,src=/h,dst=/c'],
       network: 'hive-formal-ai',
+      networks: ['hive-formal-ai', 'public-egress'],
       networkAliases: ['formal-ai', 'checker'],
     });
     assert.deepStrictEqual(args, [
@@ -264,6 +272,7 @@ describe('buildDockerRuntimeStatusLines', () => {
       env: ['FOO=bar'],
       privileged: true,
       network: 'hive-formal-ai',
+      networks: ['hive-formal-ai', 'public-egress'],
       networkAliases: ['formal-ai', 'checker'],
     });
     assert.deepStrictEqual(lines, [
@@ -272,6 +281,7 @@ describe('buildDockerRuntimeStatusLines', () => {
       '[Isolation] Env: FOO=bar',
       '[Isolation] Privileged: true',
       '[Isolation] Network: hive-formal-ai',
+      '[Isolation] Networks: hive-formal-ai, public-egress',
       '[Isolation] Network aliases: formal-ai, checker',
     ]);
   });
@@ -292,6 +302,7 @@ describe('buildDockerRuntimeMetadata', () => {
       env: null,
       privileged: null,
       network: null,
+      networks: null,
       networkAliases: null,
     });
   });
@@ -304,6 +315,7 @@ describe('buildDockerRuntimeMetadata', () => {
         env: ['FOO=bar'],
         privileged: true,
         network: 'hive-formal-ai',
+        networks: ['hive-formal-ai', 'public-egress'],
         networkAliases: ['formal-ai', 'checker'],
       }),
       {
@@ -312,6 +324,7 @@ describe('buildDockerRuntimeMetadata', () => {
         env: ['FOO=bar'],
         privileged: true,
         network: 'hive-formal-ai',
+        networks: ['hive-formal-ai', 'public-egress'],
         networkAliases: ['formal-ai', 'checker'],
       }
     );

--- a/rust/changelog.d/156.md
+++ b/rust/changelog.d/156.md
@@ -1,0 +1,5 @@
+---
+bump: minor
+---
+
+Allow Docker isolation to join multiple networks before starting the command.

--- a/rust/src/bin/main.rs
+++ b/rust/src/bin/main.rs
@@ -616,6 +616,7 @@ fn run_with_isolation(
             env: wrapper_options.env.clone(),
             privileged: wrapper_options.privileged,
             network: wrapper_options.network.clone(),
+            networks: wrapper_options.networks.clone(),
             network_aliases: wrapper_options.network_aliases.clone(),
             endpoint: wrapper_options.endpoint.clone(),
             detached: mode == "detached",

--- a/rust/src/lib/args_parser.rs
+++ b/rust/src/lib/args_parser.rs
@@ -14,8 +14,8 @@
 //! --mount <mount-spec>             Docker --mount spec (repeatable, docker only)
 //! --env, -e <KEY=VALUE>            Environment variable for docker container (repeatable, docker only)
 //! --privileged                     Run docker container in privileged mode (docker only)
-//! --network <name>                 Connect docker container to a named network (docker only)
-//! --network-alias <alias>          Add a network-scoped alias (repeatable, docker only)
+//! --network <name>                 Connect docker container to a named network (repeatable, docker only)
+//! --network-alias <alias>          Add an alias to the first network (repeatable, docker only)
 //! --endpoint <endpoint>            SSH endpoint (required for ssh isolation, e.g., user@host)
 //! --isolated-user, -u [username]   Create isolated user with same permissions
 //! --keep-user                      Keep isolated user after command completes
@@ -82,8 +82,10 @@ pub struct WrapperOptions {
     pub env: Vec<String>,
     /// Run docker container in privileged mode
     pub privileged: bool,
-    /// Docker network name
+    /// First Docker network name (compatibility accessor)
     pub network: Option<String>,
+    /// Ordered Docker network names
+    pub networks: Vec<String>,
     /// Docker network-scoped aliases
     pub network_aliases: Vec<String>,
     /// SSH endpoint (e.g., user@host)
@@ -140,6 +142,7 @@ impl Default for WrapperOptions {
             env: Vec::new(),
             privileged: false,
             network: None,
+            networks: Vec::new(),
             network_aliases: Vec::new(),
             endpoint: None,
             user: false,
@@ -378,7 +381,11 @@ fn parse_option(
     // --network (for docker)
     if arg == "--network" {
         if index + 1 < args.len() && !args[index + 1].starts_with('-') {
-            options.network = Some(args[index + 1].clone());
+            let network = args[index + 1].clone();
+            options.networks.push(network.clone());
+            if options.network.is_none() {
+                options.network = Some(network);
+            }
             return Ok(2);
         }
         return Err(format!("Option {} requires a network name argument", arg));
@@ -386,7 +393,11 @@ fn parse_option(
 
     // --network=<value>
     if let Some(value) = arg.strip_prefix("--network=") {
-        options.network = Some(value.to_string());
+        let network = value.to_string();
+        options.networks.push(network.clone());
+        if options.network.is_none() {
+            options.network = Some(network);
+        }
         return Ok(1);
     }
 

--- a/rust/src/lib/args_parser_cases.rs
+++ b/rust/src/lib/args_parser_cases.rs
@@ -217,6 +217,7 @@ fn test_docker_network_forms_preserve_child_args() {
         "docker",
         "--network",
         "hive-formal-ai",
+        "--network=public-egress",
         "--",
         "--network",
         "child-network",
@@ -243,12 +244,20 @@ fn test_docker_network_forms_preserve_child_args() {
         Some("hive-formal-ai")
     );
     assert_eq!(
+        spaced_result.wrapper_options.networks,
+        vec!["hive-formal-ai", "public-egress"]
+    );
+    assert_eq!(
         spaced_result.raw_command,
         vec!["--network", "child-network"]
     );
     assert_eq!(
         equals_result.wrapper_options.network.as_deref(),
         Some("hive-formal-ai")
+    );
+    assert_eq!(
+        equals_result.wrapper_options.networks,
+        vec!["hive-formal-ai"]
     );
 }
 
@@ -288,6 +297,7 @@ fn test_docker_runtime_options_default_empty() {
     assert!(result.wrapper_options.env.is_empty());
     assert!(!result.wrapper_options.privileged);
     assert!(result.wrapper_options.network.is_none());
+    assert!(result.wrapper_options.networks.is_empty());
     assert!(result.wrapper_options.network_aliases.is_empty());
 }
 

--- a/rust/src/lib/docker_cleanup.rs
+++ b/rust/src/lib/docker_cleanup.rs
@@ -31,7 +31,7 @@ pub(crate) fn build_docker_runtime_args(options: &IsolationOptions) -> Vec<&str>
         args.push("--mount");
         args.push(mount);
     }
-    if let Some(network) = &options.network {
+    if let Some(network) = docker_networks(options).first() {
         args.push("--network");
         args.push(network);
     }
@@ -40,6 +40,14 @@ pub(crate) fn build_docker_runtime_args(options: &IsolationOptions) -> Vec<&str>
         args.push(alias);
     }
     args
+}
+
+pub(crate) fn docker_networks(options: &IsolationOptions) -> Vec<&str> {
+    if options.networks.is_empty() {
+        options.network.iter().map(String::as_str).collect()
+    } else {
+        options.networks.iter().map(String::as_str).collect()
+    }
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]

--- a/rust/src/lib/docker_network_lifecycle.rs
+++ b/rust/src/lib/docker_network_lifecycle.rs
@@ -1,0 +1,54 @@
+//! Pre-start Docker network attachment helpers.
+
+use std::process::Command;
+
+use crate::docker_cleanup::{docker_command, docker_networks};
+use crate::isolation::IsolationOptions;
+
+fn run_docker_command(args: &[&str]) -> Result<String, String> {
+    let output = Command::new(docker_command())
+        .args(args)
+        .output()
+        .map_err(|error| error.to_string())?;
+    if output.status.success() {
+        return Ok(String::from_utf8_lossy(&output.stdout).trim().to_string());
+    }
+    let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+    let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    Err(if !stderr.is_empty() {
+        stderr
+    } else if !stdout.is_empty() {
+        stdout
+    } else {
+        format!("docker {} exited with {}", args[0], output.status)
+    })
+}
+
+fn connect_additional_networks(
+    container_name: &str,
+    options: &IsolationOptions,
+) -> Result<(), String> {
+    for network in docker_networks(options).into_iter().skip(1) {
+        run_docker_command(&["network", "connect", network, container_name])?;
+    }
+    Ok(())
+}
+
+pub(crate) fn create_and_connect(
+    create_args: &[&str],
+    container_name: &str,
+    options: &IsolationOptions,
+) -> Result<String, String> {
+    let container_id = run_docker_command(create_args)?;
+    connect_additional_networks(container_name, options)?;
+    Ok(container_id)
+}
+
+pub(crate) fn connect_and_start(
+    container_name: &str,
+    options: &IsolationOptions,
+) -> Result<(), String> {
+    connect_additional_networks(container_name, options)?;
+    run_docker_command(&["start", container_name])?;
+    Ok(())
+}

--- a/rust/src/lib/isolation.rs
+++ b/rust/src/lib/isolation.rs
@@ -13,9 +13,10 @@ use std::process::{Command, Stdio};
 use crate::args_parser::generate_session_name;
 use crate::docker_cleanup::{
     append_attached_docker_cleanup_message, append_docker_container_cleanup_policy_message,
-    build_docker_runtime_args, get_docker_container_cleanup_policy, remove_docker_container,
-    spawn_attached_docker, start_detached_docker_completion_watcher,
+    build_docker_runtime_args, docker_networks, get_docker_container_cleanup_policy,
+    remove_docker_container, spawn_attached_docker, start_detached_docker_completion_watcher,
 };
+use crate::docker_network_lifecycle::{connect_and_start, create_and_connect};
 
 /// Result of an isolation run
 #[derive(Debug, Default)]
@@ -49,8 +50,10 @@ pub struct IsolationOptions {
     pub env: Vec<String>,
     /// Run docker container in privileged mode
     pub privileged: bool,
-    /// Docker network name
+    /// First Docker network name (compatibility accessor)
     pub network: Option<String>,
+    /// Ordered Docker network names
+    pub networks: Vec<String>,
     /// Docker network-scoped aliases
     pub network_aliases: Vec<String>,
     /// SSH endpoint
@@ -85,6 +88,7 @@ impl Default for IsolationOptions {
             env: Vec::new(),
             privileged: false,
             network: None,
+            networks: Vec::new(),
             network_aliases: Vec::new(),
             endpoint: None,
             detached: false,
@@ -136,54 +140,6 @@ pub fn wrap_command_with_user(command: &str, user: Option<&str>) -> String {
             format!("sudo -n -u {} sh -c '{}'", u, escaped)
         }
         None => command.to_string(),
-    }
-}
-
-/// Shell names recognized as bare interactive shells (without -c flag).
-/// Mirrors JS SHELL_NAMES constant in isolation.js.
-const SHELL_NAMES: [&str; 8] = ["bash", "zsh", "sh", "fish", "ksh", "csh", "tcsh", "dash"];
-
-/// Returns true if command is a bare interactive shell invocation (no -c flag).
-/// Used to avoid double-wrapping shells in isolation environments (issue #84).
-///
-/// Examples: "bash", "zsh", "bash --norc", "/usr/local/bin/bash"
-/// Counter-examples: "bash -c echo hi", "npm test"
-pub fn is_interactive_shell_command(command: &str) -> bool {
-    let parts: Vec<&str> = command.split_whitespace().collect();
-    if parts.is_empty() {
-        return false;
-    }
-    let basename = parts[0].rsplit('/').next().unwrap_or(parts[0]);
-    SHELL_NAMES.contains(&basename) && !parts.contains(&"-c")
-}
-
-/// Returns true if command is a shell invocation that includes -c (e.g. `bash -i -c "cmd"`).
-/// Used to pass such commands directly without double-wrapping (issue #91).
-pub fn is_shell_invocation_with_args(command: &str) -> bool {
-    let parts: Vec<&str> = command.split_whitespace().collect();
-    if parts.is_empty() {
-        return false;
-    }
-    let basename = parts[0].rsplit('/').next().unwrap_or(parts[0]);
-    SHELL_NAMES.contains(&basename) && parts.contains(&"-c")
-}
-
-/// Build argv for a shell-with-c command; everything after -c is joined as one argument.
-/// Reverses the join(' ') that collapsed the original quoted argument.
-/// Used to pass `bash -i -c "nvm --version"` directly as argv (issue #91 fix).
-pub fn build_shell_with_args_cmd_args(command: &str) -> Vec<String> {
-    let parts: Vec<&str> = command.split_whitespace().collect();
-    let c_idx = parts.iter().position(|&p| p == "-c");
-    match c_idx {
-        None => parts.iter().map(|s| s.to_string()).collect(),
-        Some(idx) => {
-            let script_arg = parts[idx + 1..].join(" ");
-            let mut result: Vec<String> = parts[..idx + 1].iter().map(|s| s.to_string()).collect();
-            if !script_arg.is_empty() {
-                result.push(script_arg);
-            }
-            result
-        }
     }
 }
 
@@ -755,6 +711,8 @@ pub fn run_in_docker(command: &str, options: &IsolationOptions) -> IsolationResu
     println!("{}", crate::output_blocks::create_command_line(command));
     println!();
 
+    let needs_network_setup = docker_networks(options).len() > 1;
+
     if options.detached {
         let effective_command = if options.keep_alive {
             format!("{}; exec {}", command, shell_to_use)
@@ -762,7 +720,11 @@ pub fn run_in_docker(command: &str, options: &IsolationOptions) -> IsolationResu
             command.to_string()
         };
 
-        let mut args = vec!["run", "-d", "--name", &container_name];
+        let mut args = vec![if needs_network_setup { "create" } else { "run" }];
+        if !needs_network_setup {
+            args.push("-d");
+        }
+        args.extend(["--name", &container_name]);
 
         if let Some(ref user) = options.user {
             args.push("--user");
@@ -786,6 +748,21 @@ pub fn run_in_docker(command: &str, options: &IsolationOptions) -> IsolationResu
         match Command::new("docker").args(&args).output() {
             Ok(output) if output.status.success() => {
                 let container_id = String::from_utf8_lossy(&output.stdout).trim().to_string();
+
+                if needs_network_setup {
+                    let setup_result = connect_and_start(&container_name, options);
+                    if let Err(error) = setup_result {
+                        if !container_existed_before_launch {
+                            remove_docker_container(&container_name, options.log_path.as_ref());
+                        }
+                        return IsolationResult {
+                            success: false,
+                            session_name: Some(container_name),
+                            message: format!("Failed to start docker container: {}", error),
+                            ..Default::default()
+                        };
+                    }
+                }
 
                 if let Some(log_path) = options.log_path.as_ref() {
                     start_detached_docker_completion_watcher(
@@ -855,7 +832,7 @@ pub fn run_in_docker(command: &str, options: &IsolationOptions) -> IsolationResu
         }
     } else {
         // Attached mode
-        let mut args = vec!["run"];
+        let mut args = vec![if needs_network_setup { "create" } else { "run" }];
         args.push(if has_tty() { "-it" } else { "-i" });
         args.extend(["--name", &container_name]);
 
@@ -877,7 +854,27 @@ pub fn run_in_docker(command: &str, options: &IsolationOptions) -> IsolationResu
         }
         args.extend(&["-c", command]);
 
-        let child = spawn_attached_docker(&args, options.log_path.as_ref());
+        if needs_network_setup {
+            let setup_result = create_and_connect(&args, &container_name, options);
+            if let Err(error) = setup_result {
+                if !container_existed_before_launch {
+                    remove_docker_container(&container_name, options.log_path.as_ref());
+                }
+                return IsolationResult {
+                    success: false,
+                    session_name: Some(container_name),
+                    message: format!("Failed to start docker container: {}", error),
+                    ..Default::default()
+                };
+            }
+        }
+
+        let start_args = ["start", "-a", "-i", &container_name];
+        let child = if needs_network_setup {
+            spawn_attached_docker(&start_args, options.log_path.as_ref())
+        } else {
+            spawn_attached_docker(&args, options.log_path.as_ref())
+        };
 
         match child {
             Ok(child) => match child.wait() {
@@ -964,10 +961,15 @@ pub fn run_as_isolated_user(command: &str, username: &str) -> IsolationResult {
 
 #[path = "isolation_log.rs"]
 pub mod isolation_log;
+#[path = "isolation_shell.rs"]
+mod isolation_shell;
 pub use self::isolation_log::{
     append_log_file, create_log_footer, create_log_header, create_log_path,
     create_log_path_for_execution, generate_log_filename, get_default_docker_image, get_log_dir,
     get_temp_dir, get_temp_root, get_timestamp, write_log_file, LogHeaderParams,
+};
+pub use isolation_shell::{
+    build_shell_with_args_cmd_args, is_interactive_shell_command, is_shell_invocation_with_args,
 };
 
 fn is_debug() -> bool {

--- a/rust/src/lib/isolation_metadata.rs
+++ b/rust/src/lib/isolation_metadata.rs
@@ -19,6 +19,7 @@ pub fn docker_runtime_status_lines(
     env: &[String],
     privileged: bool,
     network: Option<&str>,
+    networks: &[String],
     network_aliases: &[String],
 ) -> Vec<String> {
     let mut lines = Vec::new();
@@ -34,8 +35,19 @@ pub fn docker_runtime_status_lines(
     if privileged {
         lines.push("[Isolation] Privileged: true".to_string());
     }
-    if let Some(network) = network {
-        lines.push(format!("[Isolation] Network: {}", network));
+    let resolved_networks = if networks.is_empty() {
+        network.into_iter().collect::<Vec<_>>()
+    } else {
+        networks.iter().map(String::as_str).collect::<Vec<_>>()
+    };
+    if let Some(first_network) = resolved_networks.first() {
+        lines.push(format!("[Isolation] Network: {}", first_network));
+    }
+    if resolved_networks.len() > 1 {
+        lines.push(format!(
+            "[Isolation] Networks: {}",
+            resolved_networks.join(", ")
+        ));
     }
     if !network_aliases.is_empty() {
         lines.push(format!(
@@ -54,6 +66,7 @@ pub fn docker_runtime_status_lines_for_options(options: &WrapperOptions) -> Vec<
         &options.env,
         options.privileged,
         options.network.as_deref(),
+        &options.networks,
         &options.network_aliases,
     )
 }
@@ -67,6 +80,7 @@ pub fn docker_runtime_metadata(
     env: &[String],
     privileged: bool,
     network: Option<&str>,
+    networks: &[String],
     network_aliases: &[String],
 ) -> Vec<(String, serde_json::Value)> {
     let arr = |items: &[String]| {
@@ -90,10 +104,24 @@ pub fn docker_runtime_metadata(
     if privileged {
         entries.push(("privileged".to_string(), serde_json::Value::Bool(true)));
     }
-    if let Some(network) = network {
+    let resolved_networks = if networks.is_empty() {
+        network.into_iter().collect::<Vec<_>>()
+    } else {
+        networks.iter().map(String::as_str).collect::<Vec<_>>()
+    };
+    if let Some(network) = resolved_networks.first() {
         entries.push((
             "network".to_string(),
-            serde_json::Value::String(network.to_string()),
+            serde_json::Value::String((*network).to_string()),
+        ));
+        entries.push((
+            "networks".to_string(),
+            serde_json::Value::Array(
+                resolved_networks
+                    .iter()
+                    .map(|value| serde_json::Value::String((*value).to_string()))
+                    .collect(),
+            ),
         ));
     }
     if !network_aliases.is_empty() {
@@ -130,6 +158,7 @@ pub fn build_isolation_options_map(
         &options.env,
         options.privileged,
         options.network.as_deref(),
+        &options.networks,
         &options.network_aliases,
     ) {
         opts_map.insert(k, v);

--- a/rust/src/lib/isolation_metadata_cases.rs
+++ b/rust/src/lib/isolation_metadata_cases.rs
@@ -2,7 +2,7 @@ use super::*;
 
 #[test]
 fn test_docker_runtime_status_lines_empty() {
-    assert!(docker_runtime_status_lines(&[], &[], &[], false, None, &[]).is_empty());
+    assert!(docker_runtime_status_lines(&[], &[], &[], false, None, &[], &[]).is_empty());
 }
 
 #[test]
@@ -13,6 +13,7 @@ fn test_docker_runtime_status_lines_populated() {
         &["FOO=bar".to_string()],
         true,
         Some("hive-formal-ai"),
+        &["hive-formal-ai".to_string(), "public-egress".to_string()],
         &["formal-ai".to_string(), "checker".to_string()],
     );
     assert_eq!(
@@ -23,6 +24,7 @@ fn test_docker_runtime_status_lines_populated() {
             "[Isolation] Env: FOO=bar".to_string(),
             "[Isolation] Privileged: true".to_string(),
             "[Isolation] Network: hive-formal-ai".to_string(),
+            "[Isolation] Networks: hive-formal-ai, public-egress".to_string(),
             "[Isolation] Network aliases: formal-ai, checker".to_string(),
         ]
     );
@@ -37,13 +39,14 @@ fn test_docker_runtime_status_lines_joins_multiple() {
         false,
         None,
         &[],
+        &[],
     );
     assert_eq!(lines, vec!["[Isolation] Volumes: /a:/a, /b:/b".to_string()]);
 }
 
 #[test]
 fn test_docker_runtime_metadata_empty() {
-    assert!(docker_runtime_metadata(&[], &[], &[], false, None, &[]).is_empty());
+    assert!(docker_runtime_metadata(&[], &[], &[], false, None, &[], &[]).is_empty());
 }
 
 #[test]
@@ -54,6 +57,7 @@ fn test_docker_runtime_metadata_populated() {
         &["FOO=bar".to_string()],
         true,
         Some("hive-formal-ai"),
+        &["hive-formal-ai".to_string(), "public-egress".to_string()],
         &["formal-ai".to_string(), "checker".to_string()],
     );
     let map: std::collections::HashMap<_, _> = entries.into_iter().collect();
@@ -75,6 +79,10 @@ fn test_docker_runtime_metadata_populated() {
         Some(&serde_json::json!("hive-formal-ai"))
     );
     assert_eq!(
+        map.get("networks"),
+        Some(&serde_json::json!(["hive-formal-ai", "public-egress"]))
+    );
+    assert_eq!(
         map.get("networkAliases"),
         Some(&serde_json::json!(["formal-ai", "checker"]))
     );
@@ -82,7 +90,7 @@ fn test_docker_runtime_metadata_populated() {
 
 #[test]
 fn test_docker_runtime_metadata_omits_privileged_when_false() {
-    let entries = docker_runtime_metadata(&["/h:/c".to_string()], &[], &[], false, None, &[]);
+    let entries = docker_runtime_metadata(&["/h:/c".to_string()], &[], &[], false, None, &[], &[]);
     let map: std::collections::HashMap<_, _> = entries.into_iter().collect();
     assert!(map.contains_key("volumes"));
     assert!(!map.contains_key("privileged"));
@@ -122,6 +130,7 @@ fn test_build_isolation_options_map_includes_runtime_options() {
         env: vec!["TOKEN=abc".to_string()],
         privileged: true,
         network: Some("hive-formal-ai".to_string()),
+        networks: vec!["hive-formal-ai".to_string(), "public-egress".to_string()],
         network_aliases: vec!["formal-ai".to_string(), "checker".to_string()],
         ..Default::default()
     };
@@ -145,6 +154,10 @@ fn test_build_isolation_options_map_includes_runtime_options() {
     assert_eq!(
         map.get("network"),
         Some(&serde_json::json!("hive-formal-ai"))
+    );
+    assert_eq!(
+        map.get("networks"),
+        Some(&serde_json::json!(["hive-formal-ai", "public-egress"]))
     );
     assert_eq!(
         map.get("networkAliases"),

--- a/rust/src/lib/isolation_shell.rs
+++ b/rust/src/lib/isolation_shell.rs
@@ -1,0 +1,37 @@
+//! Shell command classification shared by isolation backends.
+
+const SHELL_NAMES: [&str; 8] = ["bash", "zsh", "sh", "fish", "ksh", "csh", "tcsh", "dash"];
+
+pub fn is_interactive_shell_command(command: &str) -> bool {
+    let parts: Vec<&str> = command.split_whitespace().collect();
+    if parts.is_empty() {
+        return false;
+    }
+    let basename = parts[0].rsplit('/').next().unwrap_or(parts[0]);
+    SHELL_NAMES.contains(&basename) && !parts.contains(&"-c")
+}
+
+pub fn is_shell_invocation_with_args(command: &str) -> bool {
+    let parts: Vec<&str> = command.split_whitespace().collect();
+    if parts.is_empty() {
+        return false;
+    }
+    let basename = parts[0].rsplit('/').next().unwrap_or(parts[0]);
+    SHELL_NAMES.contains(&basename) && parts.contains(&"-c")
+}
+
+pub fn build_shell_with_args_cmd_args(command: &str) -> Vec<String> {
+    let parts: Vec<&str> = command.split_whitespace().collect();
+    let Some(index) = parts.iter().position(|&part| part == "-c") else {
+        return parts.iter().map(|part| (*part).to_string()).collect();
+    };
+    let script = parts[index + 1..].join(" ");
+    let mut result = parts[..=index]
+        .iter()
+        .map(|part| (*part).to_string())
+        .collect::<Vec<_>>();
+    if !script.is_empty() {
+        result.push(script);
+    }
+    result
+}

--- a/rust/src/lib/mod.rs
+++ b/rust/src/lib/mod.rs
@@ -4,6 +4,7 @@
 
 pub mod args_parser;
 pub(crate) mod docker_cleanup;
+mod docker_network_lifecycle;
 pub mod execution_control;
 pub mod execution_store;
 pub mod failure_handler;

--- a/rust/src/lib/usage.rs
+++ b/rust/src/lib/usage.rs
@@ -21,8 +21,8 @@ Options:
   --mount <spec>        Docker --mount spec (repeatable, docker only)
   --env, -e <KEY=VALUE> Environment variable for docker container (repeatable, docker only)
   --privileged          Run docker container in privileged mode (docker only)
-  --network <name>      Connect docker container to a named network (docker only)
-  --network-alias <alias> Add network-scoped alias (repeatable, docker only)
+  --network <name>      Connect to a named network (repeatable, docker only)
+  --network-alias <alias> Add alias to the first network (repeatable, docker only)
   --endpoint <endpoint> SSH endpoint (required for ssh isolation, e.g., user@host)
   --isolated-user, -u [name]  Create isolated user with same permissions
   --keep-user           Keep isolated user after command completes

--- a/rust/tests/docker_network.rs
+++ b/rust/tests/docker_network.rs
@@ -1,4 +1,4 @@
-//! Real-daemon integration coverage for Docker network isolation (issue #154).
+//! Real-daemon integration coverage for Docker network isolation (issues #154, #156).
 
 use start_command::isolation::run_in_docker;
 use start_command::IsolationOptions;
@@ -77,12 +77,12 @@ fn named_network_alias_is_private_and_missing_network_leaves_no_orphan() {
     );
 
     let joined = run_in_docker(
-        "ping -c 1 formal-ai",
+        "ping -c 1 formal-ai && wget -q --spider https://api.github.com",
         &IsolationOptions {
             image: Some("alpine:3.23".to_string()),
             session: Some(connected),
-            network: Some(network.clone()),
-            network_aliases: vec!["task".to_string()],
+            network: Some("bridge".to_string()),
+            networks: vec!["bridge".to_string(), network.clone()],
             detached: true,
             shell: "sh".to_string(),
             keep_container: true,
@@ -119,6 +119,21 @@ fn named_network_alias_is_private_and_missing_network_leaves_no_orphan() {
         },
     );
     assert!(!failed.success);
+    assert!(!docker(&["inspect", &missing]).status.success());
+
+    let failed_second = run_in_docker(
+        "echo should-not-run",
+        &IsolationOptions {
+            image: Some("alpine:3.23".to_string()),
+            session: Some(missing.clone()),
+            network: Some("bridge".to_string()),
+            networks: vec!["bridge".to_string(), format!("{network}-absent")],
+            detached: true,
+            shell: "sh".to_string(),
+            ..Default::default()
+        },
+    );
+    assert!(!failed_second.success);
     assert!(!docker(&["inspect", &missing]).status.success());
 
     let conflict = run_in_docker(


### PR DESCRIPTION
Fixes #156

## Summary

- make `--network` repeatable in both the JavaScript and Rust CLIs while preserving the first-network compatibility field
- create multi-network containers first, attach every additional network, and only then start the command, eliminating the startup race
- clean up newly created containers when an additional network cannot be attached
- expose the ordered network list in status output and execution metadata
- document that repeatable `--network-alias` values belong to the first network
- add JavaScript and Rust release fragments for the new CLI capability

## Reproduction and regression coverage

Before this change, parsing multiple `--network` flags retained only the last value, and Docker isolation could not place a command on both a private service network and an egress-capable network before it started.

The new real-daemon integration tests launch a sidecar on an internal network, then verify that the command container can reach both the sidecar alias and `api.github.com` through two networks. They also verify that failure to attach the second network leaves no orphaned container. Parser, runtime-argument, status, and metadata unit coverage verifies network ordering and backward compatibility.

## Verification

- `cd js && bun run test` — 712 passing
- `cd rust && cargo test --all-targets --all-features` — all unit, integration, and doc tests passing
- `cd js && bun run check`
- `cd rust && cargo fmt --check`
- `cd rust && cargo clippy --all-targets --all-features -- -D warnings`
- file-size, JS/Rust parity, documentation-example, and changeset checks
- real Docker network integration suites for JavaScript and Rust

Screenshots are not applicable because this is a CLI/runtime behavior change.
